### PR TITLE
fix readme yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Create a profile like this one:
 ```yaml
 fabric-spark-test:
   target: fabricspark-dev
+  outputs:
     fabricspark-dev:
         authentication: CLI
         method: livy


### PR DESCRIPTION
Fix the example profile yaml in the README. The current yaml omits the `outputs:` line, resulting in an error:

```
Runtime Error
  Syntax error near line 3
  ------------------------------
  1  | jaffle_shop:
  2  |   target: fabricspark-dev
  3  |     fabricspark-dev:
  4  |         authentication: CLI
  5  |         method: livy
  6  |         connect_retries: 0

  Raw Error:
  ------------------------------
  mapping values are not allowed in this context
    in "<unicode string>", line 3, column 20
```