### PR TITLE
Update valid session states

### DIFF
--- a/dbt/adapters/fabricspark/fabric_spark_credentials.py
+++ b/dbt/adapters/fabricspark/fabric_spark_credentials.py
@@ -11,7 +11,7 @@ class SparkCredentials(Credentials):
     database: Optional[str] = None
     lakehouse: str = None
     lakehouseid: str = None  # type: ignore    
-    endpoint: Optional[str] = "https://msitapi.fabric.microsoft.com/v1"
+    endpoint: Optional[str] = "https://api.fabric.microsoft.com/v1"
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
     tenant_id: Optional[str] = None


### PR DESCRIPTION
- Update the valid session states in `is_valid_session` -- should speed up execution significantly
- Add a print statement when the session is starting up since it takes a while and the console is currently just blank for about 1.5 minutes
- Change the base endpoint to the public-facing endpoint (api.fabric.microsoft.com)