### PR TITLE
try-except shortcut creation, use endpoint specified in profiles.yml for checking/creating shortcuts

### DIFF
--- a/dbt/adapters/fabricspark/connections.py
+++ b/dbt/adapters/fabricspark/connections.py
@@ -189,7 +189,7 @@ class SparkConnectionManager(SQLConnectionManager):
             raise exc  # type: ignore
 
         if handle is None:
-            raise dbt.exceptions.FailedToConnectError("Failed to connect to Livy")
+            raise dbt.exceptions.FailedToConnectError("Failed to connect to Livy session. Common reasons for errors: \n1. Invalid/expired credentials (if using CLI authentication, re-run `az login` in your terminal) \n2. Invalid endpoint \n3. Invalid workspaceid or lakehouseid (do you have the correct permissions?) \n4. Invalid or non-existent shortcuts json path, or improperly formatted shortcuts")
         connection.handle = handle
         connection.state = ConnectionState.OPEN
         return connection

--- a/dbt/adapters/fabricspark/livysession.py
+++ b/dbt/adapters/fabricspark/livysession.py
@@ -193,6 +193,9 @@ class LivySession:
             logger.error(f"Unable to close the livy session {self.session_id}, error: {ex}")
 
     def is_valid_session(self) -> bool:
+        if (self.session_id is None):
+            logger.error("Session ID is None")
+            return False
         res = requests.get(
             self.connect_url + "/sessions/" + self.session_id,
             headers=get_headers(self.credential, False),
@@ -473,9 +476,9 @@ class LivySessionManager:
         # the following opens an spark / sql session
         data = {"kind": "sql", "conf": credentials.livy_session_parameters}  # 'spark'
         if __class__.livy_global_session is None:
-            __class__.livy_global_session = LivySession(credentials)
-            __class__.livy_global_session.create_session(data)
-            __class__.livy_global_session.is_new_session_required = False
+            # __class__.livy_global_session = LivySession(credentials)
+            # __class__.livy_global_session.create_session(data)
+            # __class__.livy_global_session.is_new_session_required = False
             # create shortcuts, if there are any
             if credentials.shortcuts_json_path:
                 try:
@@ -497,9 +500,11 @@ class LivySessionManager:
 
     @staticmethod
     def disconnect() -> None:
-        if __class__.livy_global_session.is_valid_session():
+        if __class__.livy_global_session is not None and __class__.livy_global_session.is_valid_session():
             __class__.livy_global_session.delete_session()
             __class__.livy_global_session.is_new_session_required = True
+        else:
+            logger.debug("No session to disconnect")
 
 
 class LivySessionConnectionWrapper(object):

--- a/dbt/adapters/fabricspark/livysession.py
+++ b/dbt/adapters/fabricspark/livysession.py
@@ -476,9 +476,9 @@ class LivySessionManager:
         # the following opens an spark / sql session
         data = {"kind": "sql", "conf": credentials.livy_session_parameters}  # 'spark'
         if __class__.livy_global_session is None:
-            # __class__.livy_global_session = LivySession(credentials)
-            # __class__.livy_global_session.create_session(data)
-            # __class__.livy_global_session.is_new_session_required = False
+            __class__.livy_global_session = LivySession(credentials)
+            __class__.livy_global_session.create_session(data)
+            __class__.livy_global_session.is_new_session_required = False
             # create shortcuts, if there are any
             if credentials.shortcuts_json_path:
                 try:

--- a/dbt/adapters/fabricspark/livysession.py
+++ b/dbt/adapters/fabricspark/livysession.py
@@ -478,8 +478,11 @@ class LivySessionManager:
             __class__.livy_global_session.is_new_session_required = False
             # create shortcuts, if there are any
             if credentials.shortcuts_json_path:
-                shortcut_client = ShortcutClient(accessToken.token, credentials.workspaceid, credentials.lakehouseid)
-                shortcut_client.create_shortcuts(credentials.shortcuts_json_path)
+                try:
+                    shortcut_client = ShortcutClient(accessToken.token, credentials.workspaceid, credentials.lakehouseid, credentials.endpoint)
+                    shortcut_client.create_shortcuts(credentials.shortcuts_json_path)
+                except Exception as ex:
+                    logger.error(f"Unable to create shortcuts: {ex}")
         elif not __class__.livy_global_session.is_valid_session():
             __class__.livy_global_session.delete_session()
             __class__.livy_global_session.create_session(data)

--- a/dbt/adapters/fabricspark/shortcuts.py
+++ b/dbt/adapters/fabricspark/shortcuts.py
@@ -60,11 +60,11 @@ class Shortcut:
         """
         return f"Shortcut: {self.shortcut_name} from {self.source_path} to {self.path}"
     
-    def connect_url(self):
+    def connect_url(self, endpoint: str = "https://api.fabric.microsoft.com/v1"):
         """
         Returns the connect URL for the shortcut.
         """
-        return f"https://api.fabric.microsoft.com/v1/workspaces/{self.source_workspace_id}/items/{self.source_item_id}/shortcuts/{self.source_path}/{self.shortcut_name}"
+        return f"{endpoint}/workspaces/{self.source_workspace_id}/items/{self.source_item_id}/shortcuts/{self.source_path}/{self.shortcut_name}"
     
     def get_target_body(self):
         """
@@ -81,7 +81,7 @@ class Shortcut:
 
 
 class ShortcutClient:
-    def __init__(self, token: str, workspace_id: str, item_id: str):
+    def __init__(self, token: str, workspace_id: str, item_id: str, endpoint: str = "https://api.fabric.microsoft.com/v1"):
         """
         Initializes a ShortcutClient object.
 
@@ -93,6 +93,7 @@ class ShortcutClient:
         self.token = token
         self.workspace_id = workspace_id
         self.item_id = item_id
+        self.endpoint = endpoint
 
     def parse_json(self, json_str: str):
         """
@@ -102,15 +103,19 @@ class ShortcutClient:
             json_str (str): The JSON string to parse.
         """
         shortcuts = []
-        for shortcut in json.loads(json_str):
-            # convert string target to TargetName enum
-            shortcut["target"] = TargetName(shortcut["target"])
-            try:
-                shortcut_obj = Shortcut(**shortcut)
-            except Exception as e:
-                raise ValueError(f"Could not parse shortcut: {shortcut} with error: {e}")
-            shortcuts.append(shortcut_obj)
-        return shortcuts
+        try:
+            parsed_json = json.loads(json_str)
+            for shortcut in parsed_json:
+                # convert string target to TargetName enum
+                shortcut["target"] = TargetName(shortcut["target"])
+                try:
+                    shortcut_obj = Shortcut(**shortcut)
+                except Exception as e:
+                    raise ValueError(f"Could not parse shortcut: {shortcut} with error: {e}")
+                shortcuts.append(shortcut_obj)
+            return shortcuts
+        except Exception as e:
+            raise ValueError(f"Could not parse JSON: {json_str} with error: {e}")
     
     def create_shortcuts(self, json_path: str, max_retries: int = 3):
         """
@@ -148,7 +153,7 @@ class ShortcutClient:
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json"
         }
-        response = requests.get(shortcut.connect_url(), headers=headers)
+        response = requests.get(shortcut.connect_url(self.endpoint), headers=headers)
         # check if the error is ItemNotFound
         if response.status_code == 404:
             return False
@@ -172,7 +177,7 @@ class ShortcutClient:
             shortcut_path (str): The path where the shortcut is located.
             shortcut_name (str): The name of the shortcut.
         """
-        connect_url = f"https://api.fabric.microsoft.com/v1/workspaces/{self.workspace_id}/items/{self.item_id}/shortcuts/{shortcut_path}/{shortcut_name}"
+        connect_url = f"{self.endpoint}/workspaces/{self.workspace_id}/items/{self.item_id}/shortcuts/{shortcut_path}/{shortcut_name}"
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json"
@@ -191,7 +196,7 @@ class ShortcutClient:
         if self.check_exists(shortcut):
             logger.debug(f"Shortcut {shortcut} already exists, skipping...")
             return
-        connect_url = f"https://api.fabric.microsoft.com/v1/workspaces/{self.workspace_id}/items/{self.item_id}/shortcuts"
+        connect_url = f"{self.endpoint}/workspaces/{self.workspace_id}/items/{self.item_id}/shortcuts"
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json"


### PR DESCRIPTION
cleaning up some issues I found when preparing the demo:
- try-except shortcut creation so that if it fails there is a more informative error message than "failed to connect to Livy" (which also isn't true)
- try-except json parsing for reason above
- use the endpoint specified in profiles.yml (defaulting to public endpoint) for checking whether a shortcut exists and creating it if not