### PR TITLE
Fix dbt hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `dbt-fabricspark` package contains all of the code enabling dbt to work with
 - Read the [introduction](https://docs.getdbt.com/docs/introduction/) and [viewpoint](https://docs.getdbt.com/docs/about/viewpoint/)
 
 ## Running locally
-Use livy endpoint to connect to Synapse Spark in Microsoft Fabric. The binaries required to setup local environment is not possiblw with Synapse Spark in Microsoft Fabric. However, you can configure profile to connect via livy endpoints.
+Use livy endpoint to connect to Synapse Spark in Microsoft Fabric. The binaries required to setup local environment is not possible with Synapse Spark in Microsoft Fabric. However, you can configure profile to connect via livy endpoints.
 
 Create a profile like this one:
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </a>
 
 <br>
+
 [dbt](https://www.getdbt.com/) enables data analysts and engineers to transform their data using the same practices that software engineers use to build applications.
 
 dbt is the T in ELT. Organize, cleanse, denormalize, filter, rename, and pre-aggregate the raw data in your warehouse so that it's ready for analysis.


### PR DESCRIPTION
We need a need line after `<br>` to help the Markdown parser interpret the next line as actual Markdown.