### PR TITLE
Adding support of cross lakehouse write scenarios

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
     schedule:
       interval: "daily"
     rebase-strategy: "disabled"
+    open-pull-requests-limit: 0

--- a/README.md
+++ b/README.md
@@ -1,90 +1,221 @@
+<a href="https://github.com/microsoft/dbt-fabricspark/actions/workflows/ci.yml">
+  <img src="https://github.com/microsoft/dbt-fabricspark/actions/workflows/ci.yml/badge.svg?branch=main" alt="Tests and Code Checks"/>
+</a>
 <a href="https://github.com/microsoft/dbt-fabricspark/actions/workflows/integration.yml">
   <img src="https://github.com/microsoft/dbt-fabricspark/actions/workflows/integration.yml/badge.svg?branch=main&event=pull_request" alt="Adapter Integration Tests"/>
 </a>
+<a href="https://github.com/microsoft/dbt-fabricspark/actions/workflows/release.yml">
+  <img src="https://github.com/microsoft/dbt-fabricspark/actions/workflows/release.yml/badge.svg" alt="Release to PyPI"/>
+</a>
+
+![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)
+![dbt-core](https://img.shields.io/badge/dbt--core-%3E%3D1.8.0-orange)
+![License](https://img.shields.io/badge/license-MIT-green)
 
 <br>
+
 [dbt](https://www.getdbt.com/) enables data analysts and engineers to transform their data using the same practices that software engineers use to build applications.
 
 dbt is the T in ELT. Organize, cleanse, denormalize, filter, rename, and pre-aggregate the raw data in your warehouse so that it's ready for analysis.
 
 ## dbt-fabricspark
 
-The `dbt-fabricspark` package contains all of the code enabling dbt to work with Synapse Spark in Microsoft Fabric. For more information, consult [the docs](https://docs.getdbt.com/docs/profile-fabricspark).
+The `dbt-fabricspark` package contains all of the code enabling dbt to work with Apache Spark in Microsoft Fabric. This adapter connects to Fabric Lakehouses via Livy endpoints and supports both **schema-enabled** and **non-schema** Lakehouse configurations.
+
+**Current version: `1.9.3`**
+
+### Key Features
+
+- **Livy session management** with session reuse across dbt runs
+- **Lakehouse with schema support** — auto-detects schema-enabled lakehouses and uses three-part naming (`lakehouse.schema.table`)
+- **Lakehouse without schema** — standard two-part naming (`lakehouse.table`)
+- **Materializations**: table, view, incremental (append, merge, insert_overwrite), seed, snapshot
+- **Fabric Environment support** via `environmentId` configuration
+- **Security**: credential masking, UUID validation, HTTPS + domain validation, thread-safe token refresh
+- **Resilience**: HTTP 5xx retry with exponential backoff, bounded polling with configurable timeouts
 
 ## Getting started
 
 - [Install dbt](https://docs.getdbt.com/docs/installation)
 - Read the [introduction](https://docs.getdbt.com/docs/introduction/) and [viewpoint](https://docs.getdbt.com/docs/about/viewpoint/)
 
-## Running locally
-Use livy endpoint to connect to Synapse Spark in Microsoft Fabric. The binaries required to setup local environment is not possiblw with Synapse Spark in Microsoft Fabric. However, you can configure profile to connect via livy endpoints.
+### Installation
 
-Create a profile like this one:
+```bash
+pip install dbt-fabricspark
+```
+
+## Configuration
+
+Use a Livy endpoint to connect to Apache Spark in Microsoft Fabric. Configure your `profiles.yml` to connect via Livy endpoints.
+
+### Lakehouse without Schema
+
+For standard Lakehouses (schema not enabled), use two-part naming. The `schema` field is set to the lakehouse name:
 
 ```yaml
 fabric-spark-test:
   target: fabricspark-dev
   outputs:
     fabricspark-dev:
-        authentication: CLI
-        method: livy
-        connect_retries: 0
-        connect_timeout: 10
-        endpoint: https://api.fabric.microsoft.com/v1
-        workspaceid: bab084ca-748d-438e-94ad-405428bd5694
-        lakehouseid: ccb45a7d-60fc-447b-b1d3-713e05f55e9a
-        lakehouse: test
-        schema: test
-        threads: 1
+        # Connection
         type: fabricspark
+        method: livy
+        endpoint: https://api.fabric.microsoft.com/v1
+        workspaceid: <your-workspace-id>
+        lakehouseid: <your-lakehouse-id>
+        lakehouse: my_lakehouse
+        schema: my_lakehouse
+        threads: 1
+
+        # Authentication (CLI for local dev, SPN for CI/CD)
+        authentication: CLI
+        # client_id: <your-client-id>        # Required for SPN
+        # tenant_id: <your-tenant-id>        # Required for SPN
+        # client_secret: <your-client-secret> # Required for SPN
+
+        # Fabric Environment (optional)
+        # environmentId: <your-environment-id>
+
+        # Session management
+        reuse_session: true
+        session_idle_timeout: "30m"
+        # session_id_file: ./livy-session-id.txt  # Default path
+
+        # Timeouts
+        connect_retries: 1
+        connect_timeout: 10
+        http_timeout: 120                   # Seconds per HTTP request
+        session_start_timeout: 600          # Max wait for session start (10 min)
+        statement_timeout: 3600             # Max wait for statement result (1 hour)
+        poll_wait: 10                       # Seconds between session start polls
+        poll_statement_wait: 5              # Seconds between statement result polls
+
+        # Retry & Shortcuts
         retry_all: true
+        # create_shortcuts: false
+        # shortcuts_json_str: '<json-string>'
+
+        # Spark configuration (optional)
+        # spark_config:
+        #   name: "my-spark-session"
+        #   spark.executor.memory: "4g"
 ```
 
-### Session Reuse
+In this mode:
+- Tables are referenced as `lakehouse.table_name`
+- The `schema` field should match the `lakehouse` name
+- All objects are created directly under the lakehouse
 
-By default, the adapter reuses Livy sessions across dbt runs to avoid the overhead of creating new sessions each time. Session IDs are persisted to a file so they can be reused in subsequent runs.
+### Lakehouse with Schema (Schema-Enabled)
 
-**Configuration options:**
-
-- `session_id_file` (optional): Path to the file storing the Livy session ID. Defaults to `./livy-session-id.txt` in the current working directory.
-
-Example with custom session file:
+For schema-enabled Lakehouses, you can organize tables into schemas within the lakehouse. The adapter **auto-detects** whether a lakehouse has schemas enabled via the Fabric REST API (`properties.defaultSchema`):
 
 ```yaml
 fabric-spark-test:
   target: fabricspark-dev
   outputs:
     fabricspark-dev:
-        # ... other settings ...
-        session_id_file: /path/to/my-session-id.txt
+        # Connection
+        type: fabricspark
+        method: livy
+        endpoint: https://api.fabric.microsoft.com/v1
+        workspaceid: <your-workspace-id>
+        lakehouseid: <your-lakehouse-id>
+        lakehouse: my_lakehouse
+        schema: my_schema              # Different from lakehouse name
+        threads: 1
+
+        # Authentication (CLI for local dev, SPN for CI/CD)
+        authentication: CLI
+        # client_id: <your-client-id>        # Required for SPN
+        # tenant_id: <your-tenant-id>        # Required for SPN
+        # client_secret: <your-client-secret> # Required for SPN
+
+        # Fabric Environment (optional)
+        # environmentId: <your-environment-id>
+
+        # Session management
+        reuse_session: true
+        session_idle_timeout: "30m"
+        # session_id_file: ./livy-session-id.txt  # Default path
+
+        # Timeouts
+        connect_retries: 1
+        connect_timeout: 10
+        http_timeout: 120                   # Seconds per HTTP request
+        session_start_timeout: 600          # Max wait for session start (10 min)
+        statement_timeout: 3600             # Max wait for statement result (1 hour)
+        poll_wait: 10                       # Seconds between session start polls
+        poll_statement_wait: 5              # Seconds between statement result polls
+
+        # Retry & Shortcuts
+        retry_all: true
+        # create_shortcuts: false
+        # shortcuts_json_str: '<json-string>'
+
+        # Spark configuration (optional)
+        # spark_config:
+        #   name: "my-spark-session"
+        #   spark.executor.memory: "4g"
 ```
 
-**Session reuse behavior:**
+In this mode:
+- Tables are referenced using three-part naming: `lakehouse.schema.table_name`
+- The `schema` field specifies the target schema within the lakehouse
+- dbt's `generate_schema_name` and `generate_database_name` macros are lakehouse-aware
+- Schemas are created automatically via `CREATE DATABASE IF NOT EXISTS lakehouse.schema`
+- Incremental models use persisted staging tables (instead of temp views) to work around Spark's `REQUIRES_SINGLE_PART_NAMESPACE` limitation
 
-1. On first run: Creates a new Livy session and saves the session ID to the file
-2. On subsequent runs: Reads the session ID from file and attempts to reuse it
-3. If the session is invalid (dead, stopped, or doesn't exist): Creates a new session and updates the file
-4. Sessions are intentionally kept alive after dbt exits for reuse
+### Configuration Reference
 
-To force a new session, simply delete the session ID file before running dbt.
-
-### Reporting bugs and contributing code
-
--   Want to report a bug or request a feature? Let us know on [Slack](http://slack.getdbt.com/), or open [an issue](https://github.com/microsoft/dbt-fabricspark/issues/new).
-
-## Code of Conduct
-
-Everyone interacting in the Microsoft project's codebases, issue trackers, and mailing lists is expected to follow the [PyPA Code of Conduct](https://www.pypa.io/en/latest/code-of-conduct/).
-
-## Join the dbt Community
-
-- Be part of the conversation in the [dbt Community Slack](http://community.getdbt.com/)
-- Read more on the [dbt Community Discourse](https://discourse.getdbt.com)
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `type` | string | — | Must be `fabricspark` |
+| `method` | string | `livy` | Connection method |
+| `endpoint` | string | `https://api.fabric.microsoft.com/v1` | Fabric API endpoint URL |
+| `workspaceid` | string | — | Fabric workspace UUID |
+| `lakehouseid` | string | — | Lakehouse UUID |
+| `lakehouse` | string | — | Lakehouse name |
+| `schema` | string | — | Schema name (same as `lakehouse` for non-schema, different for schema-enabled) |
+| `threads` | int | `1` | Number of threads for parallel execution |
+| **Authentication** | | | |
+| `authentication` | string | `az_cli` | Auth method: `CLI` or `SPN` |
+| `client_id` | string | — | Service principal client ID (SPN only) |
+| `tenant_id` | string | — | Azure AD tenant ID (SPN only) |
+| `client_secret` | string | — | Service principal secret (SPN only) |
+| `accessToken` | string | — | Direct access token (optional) |
+| **Environment** | | | |
+| `environmentId` | string | — | Fabric Environment ID for Spark configuration |
+| `spark_config` | dict | `{}` | Spark session configuration (must include `name` key) |
+| **Session Management** | | | |
+| `reuse_session` | bool | `false` | Keep Livy sessions alive for reuse across runs |
+| `session_id_file` | string | `./livy-session-id.txt` | Path to file storing session ID for reuse |
+| `session_idle_timeout` | string | `30m` | Livy session idle timeout (e.g. `30m`, `1h`) |
+| **Timeouts & Polling** | | | |
+| `connect_retries` | int | `1` | Number of connection retries |
+| `connect_timeout` | int | `10` | Connection timeout in seconds |
+| `http_timeout` | int | `120` | Seconds per HTTP request to Fabric API |
+| `session_start_timeout` | int | `600` | Max seconds to wait for session start |
+| `statement_timeout` | int | `3600` | Max seconds to wait for statement result |
+| `poll_wait` | int | `10` | Seconds between session start polls |
+| `poll_statement_wait` | int | `5` | Seconds between statement result polls |
+| **Other** | | | |
+| `retry_all` | bool | `false` | Retry all operations on failure |
+| `create_shortcuts` | bool | `false` | Enable Fabric shortcut creation |
+| `shortcuts_json_str` | string | — | JSON string defining shortcuts |
+| `livy_mode` | string | `fabric` | `fabric` for Fabric cloud, `local` for local Livy |
+| `livy_url` | string | `http://localhost:8998` | Local Livy URL (local mode only) |
 
 ## Reporting bugs and contributing code
 
 - Want to report a bug or request a feature? Let us know on [Slack](http://community.getdbt.com/), or open [an issue](https://github.com/microsoft/dbt-fabricspark/issues/new)
 - Want to help us build dbt? Check out the [Contributing Guide](https://github.com/microsoft/dbt-fabricspark/blob/HEAD/CONTRIBUTING.md)
+
+## Join the dbt Community
+
+- Be part of the conversation in the [dbt Community Slack](http://community.getdbt.com/)
+- Read more on the [dbt Community Discourse](https://discourse.getdbt.com)
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,51 @@ In this mode:
 - Schemas are created automatically via `CREATE DATABASE IF NOT EXISTS lakehouse.schema`
 - Incremental models use persisted staging tables (instead of temp views) to work around Spark's `REQUIRES_SINGLE_PART_NAMESPACE` limitation
 
+### Schema Detection
+
+The adapter detects whether a lakehouse has schemas enabled using two complementary mechanisms:
+
+1. **Runtime detection (Fabric REST API):** During `connection.open()`, the adapter calls the Fabric REST API to fetch lakehouse properties. If the response contains `defaultSchema`, the lakehouse is treated as schema-enabled and three-part naming is used.
+
+2. **Parse-time detection (profile heuristic):** During manifest parsing (before any connection is opened), the adapter checks whether `schema` differs from `lakehouse` in your profile. When they differ (e.g., `lakehouse: bronze`, `schema: dbo`), the adapter infers schema-enabled mode. This ensures correct schema resolution at compile time.
+
+> **Important:** For schema-enabled lakehouses, always set `schema` to a value **different** from `lakehouse` in your profile (e.g., `schema: dbo`). If `schema` equals `lakehouse`, the adapter cannot distinguish schema-enabled from non-schema mode at parse time, and the lakehouse name will be used as the schema name instead.
+
+| Lakehouse Type | `lakehouse` | `schema` | Naming |
+|---|---|---|---|
+| Without schema | `my_lakehouse` | `my_lakehouse` | `my_lakehouse.table_name` |
+| With schema | `my_lakehouse` | `dbo` | `my_lakehouse.dbo.table_name` |
+
+### Cross-Lakehouse Writes
+
+A single profile can write to multiple lakehouses using the `database` config on individual models. The profile's `lakehouse` is the default target; set `database` on a model to redirect writes to a different lakehouse in the same workspace.
+
+```yaml
+# profiles.yml — profile targets the "bronze" lakehouse
+fabric-spark:
+  type: fabricspark
+  lakehouse: bronze
+  schema: dbo
+  # ... other settings
+```
+
+```sql
+-- models/silver/silver_orders.sql — writes to the "silver" lakehouse
+{{ config(
+    materialized='table',
+    database='silver',
+    schema='dbo'
+) }}
+
+select * from {{ ref('bronze_orders') }}
+```
+
+In this example:
+- Seeds and bronze models write to `bronze.dbo.*` (the default lakehouse)
+- Silver models write to `silver.dbo.*` via `database='silver'`
+- Gold models write to `gold.dbo.*` via `database='gold'`
+- All three lakehouses must exist in the same Fabric workspace and have schemas enabled
+
 ### Configuration Reference
 
 | Option | Type | Default | Description |
@@ -177,10 +222,10 @@ In this mode:
 | `workspaceid` | string | — | Fabric workspace UUID |
 | `lakehouseid` | string | — | Lakehouse UUID |
 | `lakehouse` | string | — | Lakehouse name |
-| `schema` | string | — | Schema name (same as `lakehouse` for non-schema, different for schema-enabled) |
+| `schema` | string | — | Schema name. Must equal `lakehouse` for non-schema lakehouses, must differ from `lakehouse` for schema-enabled (e.g., `dbo`) |
 | `threads` | int | `1` | Number of threads for parallel execution |
 | **Authentication** | | | |
-| `authentication` | string | `az_cli` | Auth method: `CLI` or `SPN` |
+| `authentication` | string | `CLI` | Auth method: `CLI`, `SPN`, or `fabric_notebook` |
 | `client_id` | string | — | Service principal client ID (SPN only) |
 | `tenant_id` | string | — | Azure AD tenant ID (SPN only) |
 | `client_secret` | string | — | Service principal secret (SPN only) |
@@ -206,6 +251,14 @@ In this mode:
 | `shortcuts_json_str` | string | — | JSON string defining shortcuts |
 | `livy_mode` | string | `fabric` | `fabric` for Fabric cloud, `local` for local Livy |
 | `livy_url` | string | `http://localhost:8998` | Local Livy URL (local mode only) |
+
+### Authentication Modes
+
+| Mode | Value | Use Case | Required Fields |
+|------|-------|----------|-----------------|
+| **Azure CLI** | `CLI` | Local development. Uses `az login` credentials. | None (run `az login` first) |
+| **Service Principal** | `SPN` | CI/CD and automation. Uses Azure AD app registration. | `client_id`, `tenant_id`, `client_secret` |
+| **Fabric Notebook** | `fabric_notebook` | Running dbt inside a Fabric notebook. Uses `notebookutils.credentials`. | None (runs in Fabric runtime) |
 
 ## Reporting bugs and contributing code
 

--- a/src/dbt/adapters/fabricspark/__version__.py
+++ b/src/dbt/adapters/fabricspark/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.3"
+version = "1.9.4"

--- a/src/dbt/adapters/fabricspark/credentials.py
+++ b/src/dbt/adapters/fabricspark/credentials.py
@@ -47,7 +47,7 @@ class FabricSparkCredentials(Credentials):
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
     tenant_id: Optional[str] = None
-    authentication: str = "az_cli"
+    authentication: str = "CLI"
     connect_retries: int = 1
     connect_timeout: int = 10
     create_shortcuts: Optional[bool] = False

--- a/src/dbt/adapters/fabricspark/impl.py
+++ b/src/dbt/adapters/fabricspark/impl.py
@@ -112,6 +112,10 @@ class FabricSparkAdapter(SQLAdapter):
         connection open. This avoids requiring a thread connection, which
         may not exist during manifest parsing when generate_schema_name
         is called.
+
+        Note: This returns False during manifest parsing (before connection.open).
+        The generate_schema_name macro uses a parse-time fallback by comparing
+        target.schema != target.lakehouse to infer schema-enabled mode.
         """
         return FabricSparkRelation._schemas_enabled
 

--- a/src/dbt/include/fabricspark/macros/adapters/schema.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/schema.sql
@@ -71,8 +71,16 @@
        (which maps to the single Spark database).
        For schema-enabled lakehouses, use the default dbt behavior.
        For cross-lakehouse writes (model sets database), use the custom_schema_name
-       as-is since the target default schema belongs to the source lakehouse. --#}
-  {% if adapter.is_lakehouse_schemas_enabled() or adapter.is_local_mode() %}
+       as-is since the target default schema belongs to the source lakehouse.
+
+       NOTE: adapter.is_lakehouse_schemas_enabled() is only available at runtime
+       (set during connection.open via Fabric REST API). During manifest parsing,
+       it defaults to False. As a parse-time fallback, we also check whether
+       target.schema differs from target.lakehouse — when the user sets a distinct
+       schema in profiles.yml (e.g. schema: dbo, lakehouse: bronze), that is a
+       reliable signal that the lakehouse has schemas enabled. --#}
+  {% set _schema_enabled = adapter.is_lakehouse_schemas_enabled() or adapter.is_local_mode() or (target.schema is defined and target.lakehouse is defined and target.schema != target.lakehouse) %}
+  {% if _schema_enabled %}
     {% if node and node.config and node.config.get('database') %}
       {% if custom_schema_name %}
         {% do return(custom_schema_name) %}

--- a/src/dbt/include/fabricspark/macros/adapters/schema.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/schema.sql
@@ -57,16 +57,31 @@
   {#-- Return the lakehouse name as the database.
        `database` is init=False on credentials and not in `target`, so use `lakehouse`.
        In non-schema mode, include_policy.database=False excludes it from rendered SQL.
-       In schema-enabled mode, include_policy.database=True renders three-part names. --#}
-  {% do return(target.lakehouse) %}
+       In schema-enabled mode, include_policy.database=True renders three-part names.
+       If a model explicitly sets `database`, honour it for cross-lakehouse writes. --#}
+  {% if custom_database_name %}
+    {% do return(custom_database_name) %}
+  {% else %}
+    {% do return(target.lakehouse) %}
+  {% endif %}
 {%- endmacro %}
 
 {% macro fabricspark__generate_schema_name(custom_schema_name, node) -%}
   {#-- For non-schema lakehouses, always use the lakehouse name as the schema
        (which maps to the single Spark database).
-       For schema-enabled lakehouses, use the default dbt behavior. --#}
+       For schema-enabled lakehouses, use the default dbt behavior.
+       For cross-lakehouse writes (model sets database), use the custom_schema_name
+       as-is since the target default schema belongs to the source lakehouse. --#}
   {% if adapter.is_lakehouse_schemas_enabled() or adapter.is_local_mode() %}
-    {{ return(generate_schema_name_for_env(custom_schema_name, node)) }}
+    {% if node and node.config and node.config.get('database') %}
+      {% if custom_schema_name %}
+        {% do return(custom_schema_name) %}
+      {% else %}
+        {% do return(target.schema) %}
+      {% endif %}
+    {% else %}
+      {{ return(generate_schema_name_for_env(custom_schema_name, node)) }}
+    {% endif %}
   {% else %}
     {% do return(target.lakehouse) %}
   {% endif %}

--- a/src/dbt/include/fabricspark/profile_template.yml
+++ b/src/dbt/include/fabricspark/profile_template.yml
@@ -17,7 +17,7 @@ prompts:
         hint: Use CLI (az login) for interactive execution or SPN for automation
       client_id:
         hint: Use when SPN auth is used.
-      client_scrent:
+      client_secret:
         hint: Use when SPN auth is used.
       tenant_id:
         hint: Use when SPN auth is used.

--- a/tests/functional/adapter/cross_lakehouse/test_cross_lakehouse_write.py
+++ b/tests/functional/adapter/cross_lakehouse/test_cross_lakehouse_write.py
@@ -1,0 +1,272 @@
+"""Cross-lakehouse write tests.
+
+These tests verify that dbt can write data to a *different* lakehouse
+within the same Fabric workspace. Two scenarios are covered:
+
+1. Writing to a destination lakehouse that does NOT have schemas enabled.
+2. Writing to a destination lakehouse that DOES have schemas enabled.
+
+Before running these tests, fill in the placeholder values in test.env:
+
+    # Lakehouse WITHOUT schema enabled
+    CROSS_LAKEHOUSE_NO_SCHEMA_NAME=<your-lakehouse-name>
+
+    # Lakehouse WITH schema enabled
+    CROSS_LAKEHOUSE_SCHEMA_NAME=<your-lakehouse-name>
+    CROSS_LAKEHOUSE_SCHEMA=<your-schema-name>
+
+Run with:
+    pytest tests/functional/adapter/cross_lakehouse/ -v --profile az_cli
+"""
+
+import os
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+
+# ---------------------------------------------------------------------------
+# Env-var helpers
+# ---------------------------------------------------------------------------
+
+def _cross_lakehouse_no_schema_configured() -> bool:
+    """Return True when the non-schema destination lakehouse env vars are set."""
+    name = os.getenv("CROSS_LAKEHOUSE_NO_SCHEMA_NAME", "")
+    return bool(name and not name.startswith("<"))
+
+
+def _cross_lakehouse_schema_configured() -> bool:
+    """Return True when the schema-enabled destination lakehouse env vars are set."""
+    name = os.getenv("CROSS_LAKEHOUSE_SCHEMA_NAME", "")
+    schema = os.getenv("CROSS_LAKEHOUSE_SCHEMA", "")
+    return bool(name and schema and not name.startswith("<"))
+
+
+# ---------------------------------------------------------------------------
+# Shared seed data
+# ---------------------------------------------------------------------------
+
+_seeds_csv = """id,name,value
+1,alice,100
+2,bob,200
+3,charlie,300
+""".strip()
+
+# Source table — always written to the source lakehouse (default profile target)
+_source_table_sql = """
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+select id, name, value from {{ ref('cross_seed') }}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Cross-lakehouse write to a lakehouse WITHOUT schemas
+# ---------------------------------------------------------------------------
+
+# Reads from the source table in the source lakehouse and writes to
+# the destination lakehouse. The ``database`` config maps to the
+# lakehouse name in Fabric Spark.
+_cross_lh_no_schema_table_sql = """
+{{{{
+    config(
+        materialized='table',
+        database='{dest_lakehouse}'
+    )
+}}}}
+
+select id, name, value from {{{{ ref('source_table') }}}}
+"""
+
+_cross_lh_no_schema_incremental_sql = """
+{{{{
+    config(
+        materialized='incremental',
+        database='{dest_lakehouse}',
+        incremental_strategy='append'
+    )
+}}}}
+
+select id, name, value from {{{{ ref('source_table') }}}}
+"""
+
+
+@pytest.mark.skipif(
+    not _cross_lakehouse_no_schema_configured(),
+    reason="CROSS_LAKEHOUSE_NO_SCHEMA_NAME not configured in test.env",
+)
+class TestCrossLakehouseWriteNoSchema:
+    """Write data from the source lakehouse into a different lakehouse that
+    does NOT have schemas enabled (two-part naming: lakehouse.table)."""
+
+    @pytest.fixture(scope="class")
+    def dest_lakehouse(self):
+        return os.environ["CROSS_LAKEHOUSE_NO_SCHEMA_NAME"]
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"name": "cross_lakehouse_no_schema"}
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"cross_seed.csv": _seeds_csv}
+
+    @pytest.fixture(scope="class")
+    def models(self, dest_lakehouse):
+        return {
+            "source_table.sql": _source_table_sql,
+            "cross_table_no_schema.sql": _cross_lh_no_schema_table_sql.format(
+                dest_lakehouse=dest_lakehouse,
+            ),
+            "cross_incremental_no_schema.sql": _cross_lh_no_schema_incremental_sql.format(
+                dest_lakehouse=dest_lakehouse,
+            ),
+        }
+
+    def test_seed_and_source_table(self, project):
+        """Seed data and create a source table in the source lakehouse."""
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+
+        results = run_dbt(["run", "--select", "source_table"])
+        assert len(results) == 1
+
+    def test_cross_lakehouse_table(self, project, dest_lakehouse):
+        """Read from source lakehouse table, write to destination lakehouse (no schema)."""
+        results = run_dbt(["run", "--select", "cross_table_no_schema"])
+        assert len(results) == 1
+
+        # Verify data landed in the destination lakehouse
+        result = project.run_sql(
+            f"select count(*) from {dest_lakehouse}.cross_table_no_schema",
+            fetch="one",
+        )
+        assert int(result[0]) == 3
+
+    def test_cross_lakehouse_incremental(self, project, dest_lakehouse):
+        """Read from source lakehouse table, incremental append to destination (no schema)."""
+        # First run — create
+        results = run_dbt(["run", "--select", "cross_incremental_no_schema"])
+        assert len(results) == 1
+
+        # Second run — append
+        results = run_dbt(["run", "--select", "cross_incremental_no_schema"])
+        assert len(results) == 1
+
+        # Should have 6 rows after two appends
+        result = project.run_sql(
+            f"select count(*) from {dest_lakehouse}.cross_incremental_no_schema",
+            fetch="one",
+        )
+        assert int(result[0]) == 6
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — Cross-lakehouse write to a lakehouse WITH schemas
+# ---------------------------------------------------------------------------
+
+_cross_lh_schema_table_sql = """
+{{{{
+    config(
+        materialized='table',
+        database='{dest_lakehouse}',
+        schema='{dest_schema}'
+    )
+}}}}
+
+select id, name, value from {{{{ ref('source_table') }}}}
+"""
+
+_cross_lh_schema_incremental_sql = """
+{{{{
+    config(
+        materialized='incremental',
+        database='{dest_lakehouse}',
+        schema='{dest_schema}',
+        incremental_strategy='append'
+    )
+}}}}
+
+select id, name, value from {{{{ ref('source_table') }}}}
+"""
+
+
+@pytest.mark.skipif(
+    not _cross_lakehouse_schema_configured(),
+    reason="CROSS_LAKEHOUSE_SCHEMA_NAME / _SCHEMA not configured in test.env",
+)
+class TestCrossLakehouseWriteWithSchema:
+    """Write data from the source lakehouse into a different lakehouse that
+    HAS schemas enabled (three-part naming: lakehouse.schema.table)."""
+
+    @pytest.fixture(scope="class")
+    def dest_lakehouse(self):
+        return os.environ["CROSS_LAKEHOUSE_SCHEMA_NAME"]
+
+    @pytest.fixture(scope="class")
+    def dest_schema(self):
+        return os.environ["CROSS_LAKEHOUSE_SCHEMA"]
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"name": "cross_lakehouse_with_schema"}
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"cross_seed.csv": _seeds_csv}
+
+    @pytest.fixture(scope="class")
+    def models(self, dest_lakehouse, dest_schema):
+        return {
+            "source_table.sql": _source_table_sql,
+            "cross_table_with_schema.sql": _cross_lh_schema_table_sql.format(
+                dest_lakehouse=dest_lakehouse,
+                dest_schema=dest_schema,
+            ),
+            "cross_incremental_with_schema.sql": _cross_lh_schema_incremental_sql.format(
+                dest_lakehouse=dest_lakehouse,
+                dest_schema=dest_schema,
+            ),
+        }
+
+    def test_seed_and_source_table(self, project):
+        """Seed data and create a source table in the source lakehouse."""
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+
+        results = run_dbt(["run", "--select", "source_table"])
+        assert len(results) == 1
+
+    def test_cross_lakehouse_table(self, project, dest_lakehouse, dest_schema):
+        """Read from source lakehouse table, write to destination lakehouse (schema-enabled)."""
+        results = run_dbt(["run", "--select", "cross_table_with_schema"])
+        assert len(results) == 1
+
+        # Verify data landed in destination lakehouse.schema
+        result = project.run_sql(
+            f"select count(*) from {dest_lakehouse}.{dest_schema}.cross_table_with_schema",
+            fetch="one",
+        )
+        assert int(result[0]) == 3
+
+    def test_cross_lakehouse_incremental(self, project, dest_lakehouse, dest_schema):
+        """Read from source lakehouse table, incremental append to destination (schema-enabled)."""
+        # First run — create
+        results = run_dbt(["run", "--select", "cross_incremental_with_schema"])
+        assert len(results) == 1
+
+        # Second run — append
+        results = run_dbt(["run", "--select", "cross_incremental_with_schema"])
+        assert len(results) == 1
+
+        # Should have 6 rows after two appends
+        result = project.run_sql(
+            f"select count(*) from {dest_lakehouse}.{dest_schema}.cross_incremental_with_schema",
+            fetch="one",
+        )
+        assert int(result[0]) == 6

--- a/tests/functional/adapter/cross_lakehouse/test_cross_lakehouse_write.py
+++ b/tests/functional/adapter/cross_lakehouse/test_cross_lakehouse_write.py
@@ -22,7 +22,6 @@ Run with:
 import os
 
 import pytest
-
 from dbt.tests.util import run_dbt
 
 

--- a/tests/functional/adapter/cross_lakehouse/test_cross_lakehouse_write.py
+++ b/tests/functional/adapter/cross_lakehouse/test_cross_lakehouse_write.py
@@ -22,8 +22,8 @@ Run with:
 import os
 
 import pytest
-from dbt.tests.util import run_dbt
 
+from dbt.tests.util import run_dbt
 
 # ---------------------------------------------------------------------------
 # Env-var helpers


### PR DESCRIPTION
This pull request introduces support for cross-lakehouse writes in the dbt-fabricspark adapter, allowing dbt models to write to tables in a different lakehouse (and optionally schema) than the default target. It also updates the documentation to reflect these new capabilities, adds comprehensive functional tests for cross-lakehouse scenarios, and makes minor configuration and versioning changes.

**Cross-lakehouse write support and documentation:**

* Updated `README.md` with detailed documentation on cross-lakehouse writes, schema-enabled/non-schema lakehouses, configuration options, and new features. Added CI, release, and Python/dbt compatibility badges.
* Added functional tests in `test_cross_lakehouse_write.py` to verify correct behavior when writing to a different lakehouse, both with and without schema support. Tests cover table and incremental materializations.

**Adapter logic and macro improvements:**

* Enhanced `fabricspark__generate_database_name` and `fabricspark__generate_schema_name` macros to honor explicit `database` and `schema` configs for cross-lakehouse writes, ensuring correct naming in both schema-enabled and non-schema modes.

**Project configuration and versioning:**

* Bumped adapter version to `1.9.4` in `__version__.py`.
* Disabled automatic Dependabot PRs by setting `open-pull-requests-limit: 0` in `.github/dependabot.yml`.