### PR TITLE
Fix dbt docs generate failing on cross lakehouse projects

### DIFF
--- a/src/dbt/adapters/fabricspark/impl.py
+++ b/src/dbt/adapters/fabricspark/impl.py
@@ -500,10 +500,6 @@ class FabricSparkAdapter(SQLAdapter):
         used_schemas: FrozenSet[Tuple[str, str]],
     ) -> Tuple["agate.Table", List[Exception]]:
         schema_map = self._get_catalog_schemas(relation_configs)
-        if len(schema_map) > 1:
-            raise CompilationError(
-                f"Expected only one database in get_catalog, found " f"{list(schema_map)}"
-            )
 
         with executor(self.config) as tpe:
             futures: List[Future["agate.Table"]] = []


### PR DESCRIPTION
Support for cross lakehouse writes was added in 1.9.4 however whenever more than one lakehouse exists in a workspace the `dbt docs generate` command will throw an error

```
((.venv) ) *** dbt_project % dbt docs generate
04:56:57  Running with dbt=1.11.8
04:56:57  Registered adapter: fabricspark=1.9.5
04:56:57  Building catalog
04:56:57  Encountered an error:
Compilation Error
  Expected only one database in get_catalog, found [<InformationSchema lh_silver.INFORMATION_SCHEMA>, <InformationSchema lh_gold.INFORMATION_SCHEMA>, <InformationSchema lh_bronze.INFORMATION_SCHEMA>]
```

This change removes the unnecessary `len(schema_map) > 1` guard in the `get_catalog` function that raises an error when a project writes models to multiple lakehouses/databases.

The loop below the guard already iterates over all entries in `schema_map` and handles multiple databases correctly. The restriction serves no purpose.

After removing the guard `dbt docs generate` works without issue with my three lakehouses.  It correctly attributes tables to their correct lakehouse and schema, even despite the physical table being placed in the wrong lakehouse due to the issue I raised in #83 
