### PR TITLE
feat(tools): add sync-main and nudge CLI tools for Copilot PR automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "fail-on-untracked-files": "tsx tools/scripts/fail-on-untracked-files.ts",
     "approve-copilot-gh-workflow": "tsx tools/gh-automation/approve-workflow.ts",
-    "sync-copilot-main": "tsx tools/gh-automation/sync-main.ts"
+    "sync-copilot-main": "tsx tools/gh-automation/sync-main.ts",
+    "nudge-copilot": "tsx tools/gh-automation/nudge.ts"
   },
   "type": "module",
   "nx": {}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "fail-on-untracked-files": "tsx tools/scripts/fail-on-untracked-files.ts",
-    "approve-copilot-gh-workflow": "tsx tools/gh-automation/approve-workflow.ts"
+    "approve-copilot-gh-workflow": "tsx tools/gh-automation/approve-workflow.ts",
+    "sync-copilot-main": "tsx tools/gh-automation/sync-main.ts"
   },
   "type": "module",
   "nx": {}

--- a/tools/gh-automation/README.md
+++ b/tools/gh-automation/README.md
@@ -2,11 +2,11 @@
 
 GitHub Action automations for repo maintenance. All tools discover open Copilot PRs (author: `copilot-swe-agent`) and run in a reconcile loop by default.
 
-| Tool | What it does |
-|------|-------------|
-| **approve-workflow** | Re-runs `action_required` workflow runs (GitHub UI's "Approve and run") |
-| **sync-main** | Comments on PRs whose branches are behind `main`, telling Copilot to merge and re-test |
-| **nudge** | Detects failed/cancelled/timed-out CI runs and comments telling Copilot to read logs, fix, and retry |
+| Tool                 | What it does                                                                                         |
+| -------------------- | ---------------------------------------------------------------------------------------------------- |
+| **approve-workflow** | Re-runs `action_required` workflow runs (GitHub UI's "Approve and run")                              |
+| **sync-main**        | Comments on PRs whose branches are behind `main`, telling Copilot to merge and re-test               |
+| **nudge**            | Detects failed/cancelled/timed-out CI runs and comments telling Copilot to read logs, fix, and retry |
 
 ## Usage
 

--- a/tools/gh-automation/README.md
+++ b/tools/gh-automation/README.md
@@ -1,93 +1,33 @@
 # Github automation
 
-GitHub Action automations for repo maintenance.
+GitHub Action automations for repo maintenance. All tools discover open Copilot PRs (author: `copilot-swe-agent`) and run in a reconcile loop by default.
 
-## Tools
+| Tool | What it does |
+|------|-------------|
+| **approve-workflow** | Re-runs `action_required` workflow runs (GitHub UI's "Approve and run") |
+| **sync-main** | Comments on PRs whose branches are behind `main`, telling Copilot to merge and re-test |
+| **nudge** | Detects failed/cancelled/timed-out CI runs and comments telling Copilot to read logs, fix, and retry |
 
-### approve-workflow
-
-Discovers Copilot PRs via `gh` CLI, then re-runs any `action_required` workflow
-runs using `POST /actions/runs/{id}/rerun` — this is what the GitHub UI's
-"Approve and run" button does under the hood.
-
-### sync-main
-
-Discovers Copilot PRs via `gh` CLI, checks if their branches are behind `main`,
-and posts a comment telling the Copilot agent to merge main and re-test.
-
-## Quick start
+## Usage
 
 ```bash
-# Approve workflows — watch loop every 60s (default)
-npx tsx tools/gh-automation/approve-workflow.ts
-
-# Sync branches with main — watch loop every 60s (default)
-npx tsx tools/gh-automation/sync-main.ts
-```
-
-## Examples
-
-### approve-workflow
-
-```bash
-# Watch a specific PR
-npx tsx tools/gh-automation/approve-workflow.ts 98 --sleep 360
-
-# One-shot: approve all Copilot PRs, then exit
-npx tsx tools/gh-automation/approve-workflow.ts --no-watch
-
-# One-shot: specific PR
-npx tsx tools/gh-automation/approve-workflow.ts 98 --no-watch
-
-# Dry run — see what would happen without approving anything
-npx tsx tools/gh-automation/approve-workflow.ts --dry-run
-
-# Dry run + specific PR
-npx tsx tools/gh-automation/approve-workflow.ts 98 --dry-run --no-watch
-
-# Different repo
-npx tsx tools/gh-automation/approve-workflow.ts --repo myorg/myrepo
-```
-
-### sync-main
-
-```bash
-# Watch a specific PR
-npx tsx tools/gh-automation/sync-main.ts 98 --sleep 360
-
-# One-shot: sync all Copilot PRs, then exit
-npx tsx tools/gh-automation/sync-main.ts --no-watch
-
-# One-shot: specific PR
-npx tsx tools/gh-automation/sync-main.ts 98 --no-watch
-
-# Dry run — see what would happen without commenting
-npx tsx tools/gh-automation/sync-main.ts --dry-run
-
-# Dry run + specific PR
-npx tsx tools/gh-automation/sync-main.ts 98 --dry-run --no-watch
-
-# Different repo
-npx tsx tools/gh-automation/sync-main.ts --repo myorg/myrepo
-```
-
-## npm scripts
-
-```bash
-# approve-workflow — runs in watch mode by default
+# Watch mode (reconcile every 60s) — via npm
 npm run approve-copilot-gh-workflow
-
-# sync-main — runs in watch mode by default
 npm run sync-copilot-main
+npm run nudge-copilot
 
-# Pass flags after --
-npm run approve-copilot-gh-workflow -- 98 --no-watch --dry-run
-npm run sync-copilot-main -- 98 --no-watch --dry-run
+# Or directly
+npx tsx tools/gh-automation/approve-workflow.ts
+npx tsx tools/gh-automation/sync-main.ts
+npx tsx tools/gh-automation/nudge.ts
+
+# One-shot, dry-run, specific PR — flags work on all tools
+npx tsx tools/gh-automation/nudge.ts 98 --no-watch --dry-run
 ```
 
 ## Flags
 
-Both tools share the same flag interface:
+All tools share the same interface:
 
 | Flag                     | Default                     | Description                     |
 | ------------------------ | --------------------------- | ------------------------------- |
@@ -95,19 +35,3 @@ Both tools share the same flag interface:
 | `--watch` / `--no-watch` | `--watch`                   | Reconcile loop every 60s        |
 | `--dry-run`              | `false`                     | Print actions without executing |
 | `--repo <owner/repo>`    | `microsoft/dbt-fabricspark` | Target repository               |
-
-## How it works
-
-### approve-workflow
-
-1. `gh pr list` discovers open Copilot PRs (author: `copilot-swe-agent`)
-2. `gh api` fetches workflow runs per branch, filters `conclusion === "action_required"`
-3. `gh api --method POST .../actions/runs/{id}/rerun` re-runs them as you (authorized user)
-4. In watch mode, repeats every 60 seconds
-
-### sync-main
-
-1. `gh pr list` discovers open Copilot PRs (author: `copilot-swe-agent`)
-2. `gh api repos/{owner}/{repo}/compare/main...{branch}` checks if the branch is behind main
-3. If behind, `gh pr comment` posts a message telling the Copilot agent to merge and re-test
-4. In watch mode, repeats every 60 seconds

--- a/tools/gh-automation/README.md
+++ b/tools/gh-automation/README.md
@@ -29,9 +29,10 @@ npx tsx tools/gh-automation/nudge.ts 98 --no-watch --dry-run
 
 All tools share the same interface:
 
-| Flag                     | Default                     | Description                     |
-| ------------------------ | --------------------------- | ------------------------------- |
-| `[pr-number]`            | _(all Copilot PRs)_         | Target a specific PR            |
-| `--watch` / `--no-watch` | `--watch`                   | Reconcile loop every 60s        |
-| `--dry-run`              | `false`                     | Print actions without executing |
-| `--repo <owner/repo>`    | `microsoft/dbt-fabricspark` | Target repository               |
+| Flag                     | Default                     | Description                        |
+| ------------------------ | --------------------------- | ---------------------------------- |
+| `[pr-number]`            | _(all Copilot PRs)_         | Target a specific PR               |
+| `--watch` / `--no-watch` | `--watch`                   | Reconcile loop                     |
+| `--sleep <seconds>`      | `60`                        | Seconds between reconcile loops    |
+| `--dry-run`              | `false`                     | Print actions without executing    |
+| `--repo <owner/repo>`    | `microsoft/dbt-fabricspark` | Target repository                  |

--- a/tools/gh-automation/README.md
+++ b/tools/gh-automation/README.md
@@ -2,18 +2,32 @@
 
 GitHub Action automations for repo maintenance.
 
+## Tools
+
+### approve-workflow
+
 Discovers Copilot PRs via `gh` CLI, then re-runs any `action_required` workflow
 runs using `POST /actions/runs/{id}/rerun` — this is what the GitHub UI's
 "Approve and run" button does under the hood.
 
+### sync-main
+
+Discovers Copilot PRs via `gh` CLI, checks if their branches are behind `main`,
+and posts a comment telling the Copilot agent to merge main and re-test.
+
 ## Quick start
 
 ```bash
-# Long-running watch loop — approves workflows every 60s (default)
+# Approve workflows — watch loop every 60s (default)
 npx tsx tools/gh-automation/approve-workflow.ts
+
+# Sync branches with main — watch loop every 60s (default)
+npx tsx tools/gh-automation/sync-main.ts
 ```
 
 ## Examples
+
+### approve-workflow
 
 ```bash
 # Watch a specific PR
@@ -35,17 +49,45 @@ npx tsx tools/gh-automation/approve-workflow.ts 98 --dry-run --no-watch
 npx tsx tools/gh-automation/approve-workflow.ts --repo myorg/myrepo
 ```
 
-## npm script
+### sync-main
 
 ```bash
-# Runs in watch mode by default
+# Watch a specific PR
+npx tsx tools/gh-automation/sync-main.ts 98 --sleep 360
+
+# One-shot: sync all Copilot PRs, then exit
+npx tsx tools/gh-automation/sync-main.ts --no-watch
+
+# One-shot: specific PR
+npx tsx tools/gh-automation/sync-main.ts 98 --no-watch
+
+# Dry run — see what would happen without commenting
+npx tsx tools/gh-automation/sync-main.ts --dry-run
+
+# Dry run + specific PR
+npx tsx tools/gh-automation/sync-main.ts 98 --dry-run --no-watch
+
+# Different repo
+npx tsx tools/gh-automation/sync-main.ts --repo myorg/myrepo
+```
+
+## npm scripts
+
+```bash
+# approve-workflow — runs in watch mode by default
 npm run approve-copilot-gh-workflow
+
+# sync-main — runs in watch mode by default
+npm run sync-copilot-main
 
 # Pass flags after --
 npm run approve-copilot-gh-workflow -- 98 --no-watch --dry-run
+npm run sync-copilot-main -- 98 --no-watch --dry-run
 ```
 
 ## Flags
+
+Both tools share the same flag interface:
 
 | Flag                     | Default                     | Description                     |
 | ------------------------ | --------------------------- | ------------------------------- |
@@ -56,7 +98,16 @@ npm run approve-copilot-gh-workflow -- 98 --no-watch --dry-run
 
 ## How it works
 
+### approve-workflow
+
 1. `gh pr list` discovers open Copilot PRs (author: `copilot-swe-agent`)
 2. `gh api` fetches workflow runs per branch, filters `conclusion === "action_required"`
 3. `gh api --method POST .../actions/runs/{id}/rerun` re-runs them as you (authorized user)
+4. In watch mode, repeats every 60 seconds
+
+### sync-main
+
+1. `gh pr list` discovers open Copilot PRs (author: `copilot-swe-agent`)
+2. `gh api repos/{owner}/{repo}/compare/main...{branch}` checks if the branch is behind main
+3. If behind, `gh pr comment` posts a message telling the Copilot agent to merge and re-test
 4. In watch mode, repeats every 60 seconds

--- a/tools/gh-automation/core/gh-client.ts
+++ b/tools/gh-automation/core/gh-client.ts
@@ -85,4 +85,13 @@ export class GhClient {
         const result = this.exec(args);
         return JSON.parse(result.stdout) as T;
     }
+
+    /** Post a comment on a pull request. */
+    postComment(prNumber: number, body: string): boolean {
+        const result = this.exec(
+            ['pr', 'comment', String(prNumber), '--repo', this.repo, '--body', body],
+            { fatal: false },
+        );
+        return result.status === 0;
+    }
 }

--- a/tools/gh-automation/core/logger.ts
+++ b/tools/gh-automation/core/logger.ts
@@ -61,4 +61,24 @@ export class Logger {
     syncSummary(commented: number, upToDate: number, failed: number): void {
         console.log(`\nDone. Commented on ${commented} PR(s), ${upToDate} up to date, ${failed} failed.`);
     }
+
+    ciFailure(runName: string, runId: number, conclusion: string): void {
+        console.log(`  ✗ ${runName} (run ${runId}) — ${conclusion}`);
+    }
+
+    nudgePosted(prNumber: number, runCount: number): void {
+        console.log(`  💬 Nudged PR #${prNumber} about ${runCount} failed run(s)`);
+    }
+
+    nudgeFailed(prNumber: number): void {
+        console.log(`  ✗ Failed to post nudge comment on PR #${prNumber}`);
+    }
+
+    noCiFailures(): void {
+        console.log('  ✓ No failed CI runs.');
+    }
+
+    nudgeSummary(nudged: number, clean: number, failed: number): void {
+        console.log(`\nDone. Nudged ${nudged} PR(s), ${clean} clean, ${failed} failed to comment.`);
+    }
 }

--- a/tools/gh-automation/core/logger.ts
+++ b/tools/gh-automation/core/logger.ts
@@ -41,4 +41,24 @@ export class Logger {
         const now = new Date().toLocaleTimeString();
         console.log(`\n── reconcile @ ${now} ${'─'.repeat(50)}\n`);
     }
+
+    behindMain(branch: string, behindBy: number): void {
+        console.log(`  ⬇ Branch ${branch} is ${behindBy} commit(s) behind main`);
+    }
+
+    upToDate(branch: string): void {
+        console.log(`  ✓ Branch ${branch} is up to date with main.`);
+    }
+
+    commentPosted(prNumber: number): void {
+        console.log(`  💬 Posted sync comment on PR #${prNumber}`);
+    }
+
+    commentFailed(prNumber: number): void {
+        console.log(`  ✗ Failed to post comment on PR #${prNumber}`);
+    }
+
+    syncSummary(commented: number, upToDate: number, failed: number): void {
+        console.log(`\nDone. Commented on ${commented} PR(s), ${upToDate} up to date, ${failed} failed.`);
+    }
 }

--- a/tools/gh-automation/core/nudge-service.ts
+++ b/tools/gh-automation/core/nudge-service.ts
@@ -1,0 +1,94 @@
+/**
+ * Service for nudging Copilot agents on failed CI runs.
+ *
+ * Detects failed/cancelled/timed-out workflow runs on Copilot PRs
+ * and posts a comment telling the agent to read the logs and fix.
+ */
+
+import { GhClient } from './gh-client.js';
+import { Logger } from './logger.js';
+import type { NudgeResult, PullRequest, WorkflowRun, WorkflowRunsResponse } from './types.js';
+
+const NUDGE_CONCLUSIONS = new Set(['failure', 'cancelled', 'timed_out']);
+
+function buildNudgeComment(failedRuns: WorkflowRun[]): string {
+    const runLines = failedRuns.map(
+        (r) => `- [${r.name}](${r.html_url}) — \`${r.conclusion}\``,
+    );
+
+    return [
+        '@copilot The following CI run(s) failed:',
+        '',
+        ...runLines,
+        '',
+        'Read the logs, fix your code, and push again. Keep trying until CI is green.',
+    ].join('\n');
+}
+
+export class NudgeService {
+    constructor(
+        private readonly client: GhClient,
+        private readonly logger: Logger,
+    ) {}
+
+    /** Get failed/cancelled/timed-out workflow runs for a branch. */
+    getFailedRuns(branch: string): WorkflowRun[] {
+        const encoded = encodeURIComponent(branch);
+        const response = this.client.execJson<WorkflowRunsResponse>([
+            'api',
+            `repos/${this.client.owner}/${this.client.repoName}/actions/runs?branch=${encoded}&per_page=100`,
+        ]);
+
+        if (!response) return [];
+        return response.workflow_runs.filter(
+            (r) => r.conclusion !== null && NUDGE_CONCLUSIONS.has(r.conclusion),
+        );
+    }
+
+    /** Nudge all PRs with failed CI runs. */
+    nudgeAll(prs: PullRequest[]): NudgeResult[] {
+        const results: NudgeResult[] = [];
+        let nudged = 0;
+        let clean = 0;
+        let failed = 0;
+
+        for (const pr of prs) {
+            this.logger.prHeader(pr.number, pr.title);
+
+            if (this.client.isDryRun) {
+                this.logger.dryRun(`Would check failed CI runs for branch ${pr.headRefName} and nudge if any`);
+                results.push({ pr, failedRuns: 0, commented: false });
+                continue;
+            }
+
+            const failedRuns = this.getFailedRuns(pr.headRefName);
+
+            if (failedRuns.length === 0) {
+                this.logger.noCiFailures();
+                results.push({ pr, failedRuns: 0, commented: false });
+                clean++;
+                continue;
+            }
+
+            for (const run of failedRuns) {
+                this.logger.ciFailure(run.name, run.id, run.conclusion!);
+            }
+
+            const comment = buildNudgeComment(failedRuns);
+            const success = this.client.postComment(pr.number, comment);
+
+            if (success) {
+                this.logger.nudgePosted(pr.number, failedRuns.length);
+                nudged++;
+            } else {
+                this.logger.nudgeFailed(pr.number);
+                failed++;
+            }
+
+            results.push({ pr, failedRuns: failedRuns.length, commented: success });
+        }
+
+        this.logger.nudgeSummary(nudged, clean, failed);
+        return results;
+    }
+}

--- a/tools/gh-automation/core/sync-service.ts
+++ b/tools/gh-automation/core/sync-service.ts
@@ -1,0 +1,78 @@
+/**
+ * Service for syncing Copilot PR branches with main.
+ *
+ * Checks whether each PR's branch is behind main, and if so,
+ * posts a comment telling the Copilot agent to merge and re-test.
+ */
+
+import { GhClient } from './gh-client.js';
+import { Logger } from './logger.js';
+import type { CompareResponse, PullRequest, SyncResult } from './types.js';
+
+const SYNC_COMMENT = [
+    '@copilot There have been updates to main.',
+    'Merge them into your branch, restart your task evaluation',
+    'and keep trying until CI tests run green.',
+].join(' ');
+
+export class SyncService {
+    constructor(
+        private readonly client: GhClient,
+        private readonly logger: Logger,
+    ) {}
+
+    /** Check how far behind main a branch is. Returns 0 if up to date. */
+    getBehindCount(branch: string): number {
+        const encoded = encodeURIComponent(branch);
+        const response = this.client.execJson<CompareResponse>([
+            'api',
+            `repos/${this.client.owner}/${this.client.repoName}/compare/main...${encoded}`,
+        ]);
+
+        if (!response) return 0;
+        return response.behind_by;
+    }
+
+    /** Sync all PRs: check each branch against main and comment if behind. */
+    syncAll(prs: PullRequest[]): SyncResult[] {
+        const results: SyncResult[] = [];
+        let commented = 0;
+        let upToDate = 0;
+        let failed = 0;
+
+        for (const pr of prs) {
+            this.logger.prHeader(pr.number, pr.title);
+
+            if (this.client.isDryRun) {
+                this.logger.dryRun(`Would check if ${pr.headRefName} is behind main and comment if so`);
+                results.push({ pr, behindBy: 0, commented: false });
+                continue;
+            }
+
+            const behindBy = this.getBehindCount(pr.headRefName);
+
+            if (behindBy === 0) {
+                this.logger.upToDate(pr.headRefName);
+                results.push({ pr, behindBy: 0, commented: false });
+                upToDate++;
+                continue;
+            }
+
+            this.logger.behindMain(pr.headRefName, behindBy);
+            const success = this.client.postComment(pr.number, SYNC_COMMENT);
+
+            if (success) {
+                this.logger.commentPosted(pr.number);
+                commented++;
+            } else {
+                this.logger.commentFailed(pr.number);
+                failed++;
+            }
+
+            results.push({ pr, behindBy, commented: success });
+        }
+
+        this.logger.syncSummary(commented, upToDate, failed);
+        return results;
+    }
+}

--- a/tools/gh-automation/core/types.ts
+++ b/tools/gh-automation/core/types.ts
@@ -35,6 +35,14 @@ export interface WorkflowRunsResponse {
     readonly workflow_runs: readonly WorkflowRun[];
 }
 
+// ── GitHub compare API ─────────────────────────────────────────────────────────
+
+export interface CompareResponse {
+    readonly behind_by: number;
+    readonly ahead_by: number;
+    readonly status: 'diverged' | 'ahead' | 'behind' | 'identical';
+}
+
 // ── Results ────────────────────────────────────────────────────────────────────
 
 export interface ApprovalResult {
@@ -42,4 +50,10 @@ export interface ApprovalResult {
     readonly approved: number;
     readonly skipped: number;
     readonly failed: number;
+}
+
+export interface SyncResult {
+    readonly pr: PullRequest;
+    readonly behindBy: number;
+    readonly commented: boolean;
 }

--- a/tools/gh-automation/core/types.ts
+++ b/tools/gh-automation/core/types.ts
@@ -57,3 +57,9 @@ export interface SyncResult {
     readonly behindBy: number;
     readonly commented: boolean;
 }
+
+export interface NudgeResult {
+    readonly pr: PullRequest;
+    readonly failedRuns: number;
+    readonly commented: boolean;
+}

--- a/tools/gh-automation/nudge.ts
+++ b/tools/gh-automation/nudge.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env tsx
+/**
+ * CLI entry point: nudge Copilot agents on failed CI runs.
+ *
+ * Discovers Copilot PRs via `gh` CLI, checks for failed/cancelled/timed-out
+ * workflow runs, and posts a comment telling the agent to read the logs and fix.
+ *
+ * Usage:
+ *   npx tsx tools/gh-automation/nudge.ts              # watch mode (default)
+ *   npx tsx tools/gh-automation/nudge.ts --no-watch
+ *   npx tsx tools/gh-automation/nudge.ts --dry-run
+ *   npx tsx tools/gh-automation/nudge.ts 98            # specific PR
+ */
+
+import { Command } from 'commander';
+import { Logger } from './core/logger.js';
+import { GhClient } from './core/gh-client.js';
+import { PullRequestService } from './core/pull-request-service.js';
+import { NudgeService } from './core/nudge-service.js';
+import { WatchRunner } from './core/watch-runner.js';
+import type { GhAutomationConfig, PullRequest } from './core/types.js';
+
+const program = new Command();
+
+program
+    .name('nudge')
+    .description('Nudge Copilot agents to fix failed CI runs')
+    .argument('[pr-number]', 'Specific PR number (omit to process all Copilot PRs)')
+    .option('--dry-run', 'Print actions without executing them', false)
+    .option('--watch', 'Run in an infinite reconcile loop (default: true)', true)
+    .option('--no-watch', 'Run once and exit')
+    .option('--sleep <seconds>', 'Seconds between reconcile loops', '60')
+    .option('--repo <owner/repo>', 'GitHub repository', 'microsoft/dbt-fabricspark')
+    .action(async (prNumber: string | undefined, opts: GhAutomationConfig) => {
+        const logger = new Logger();
+        const client = new GhClient(opts, logger);
+        const prService = new PullRequestService(client);
+        const nudgeService = new NudgeService(client, logger);
+        const runner = new WatchRunner(opts.watch, logger, Number(opts.sleep));
+
+        await runner.run(() => {
+            let prs: PullRequest[] | null;
+
+            if (prNumber !== undefined) {
+                const pr = prService.getByNumber(prNumber);
+                prs = pr ? [pr] : null;
+            } else {
+                prs = prService.listCopilotPRs();
+            }
+
+            if (client.isDryRun && prs === null) {
+                logger.dryRun('Would check each Copilot PR for failed CI runs and nudge.');
+                return;
+            }
+
+            if (!prs || prs.length === 0) {
+                logger.info('No PRs to process.');
+                return;
+            }
+
+            nudgeService.nudgeAll(prs);
+        });
+    });
+
+program.parse();

--- a/tools/gh-automation/sync-main.ts
+++ b/tools/gh-automation/sync-main.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env tsx
+/**
+ * CLI entry point: sync Copilot PR branches with main.
+ *
+ * Discovers Copilot PRs via `gh` CLI, checks if their branches are behind
+ * main, and posts a comment telling the Copilot agent to merge and re-test.
+ *
+ * Usage:
+ *   npx tsx tools/gh-automation/sync-main.ts              # watch mode (default)
+ *   npx tsx tools/gh-automation/sync-main.ts --no-watch
+ *   npx tsx tools/gh-automation/sync-main.ts --dry-run
+ *   npx tsx tools/gh-automation/sync-main.ts 98            # specific PR
+ */
+
+import { Command } from 'commander';
+import { Logger } from './core/logger.js';
+import { GhClient } from './core/gh-client.js';
+import { PullRequestService } from './core/pull-request-service.js';
+import { SyncService } from './core/sync-service.js';
+import { WatchRunner } from './core/watch-runner.js';
+import type { GhAutomationConfig, PullRequest } from './core/types.js';
+
+const program = new Command();
+
+program
+    .name('sync-main')
+    .description('Sync Copilot PR branches with main by posting merge comments')
+    .argument('[pr-number]', 'Specific PR number (omit to process all Copilot PRs)')
+    .option('--dry-run', 'Print actions without executing them', false)
+    .option('--watch', 'Run in an infinite reconcile loop (default: true)', true)
+    .option('--no-watch', 'Run once and exit')
+    .option('--sleep <seconds>', 'Seconds between reconcile loops', '60')
+    .option('--repo <owner/repo>', 'GitHub repository', 'microsoft/dbt-fabricspark')
+    .action(async (prNumber: string | undefined, opts: GhAutomationConfig) => {
+        const logger = new Logger();
+        const client = new GhClient(opts, logger);
+        const prService = new PullRequestService(client);
+        const syncService = new SyncService(client, logger);
+        const runner = new WatchRunner(opts.watch, logger, Number(opts.sleep));
+
+        await runner.run(() => {
+            let prs: PullRequest[] | null;
+
+            if (prNumber !== undefined) {
+                const pr = prService.getByNumber(prNumber);
+                prs = pr ? [pr] : null;
+            } else {
+                prs = prService.listCopilotPRs();
+            }
+
+            if (client.isDryRun && prs === null) {
+                logger.dryRun('Would check each Copilot PR branch against main and comment if behind.');
+                return;
+            }
+
+            if (!prs || prs.length === 0) {
+                logger.info('No PRs to process.');
+                return;
+            }
+
+            syncService.syncAll(prs);
+        });
+    });
+
+program.parse();


### PR DESCRIPTION
# Why this change is needed

When a PR merges to `main`, Copilot agents on other branches keep working with stale code (issue #108). When CI fails, Copilot agents sit idle instead of reading logs and retrying (issue #107). Both cases require manual intervention today.

Closes #107
Closes #108

# How

Two new CLI tools added to `tools/gh-automation/`, following the same architecture as the existing `approve-workflow.ts` — reusing `GhClient`, `PullRequestService`, `WatchRunner`, and `Logger`.

| Tool | What it does |
|------|-------------|
| **sync-main** | Comments on Copilot PRs whose branches are behind `main`, telling the agent to merge and re-test |
| **nudge** | Detects failed/cancelled/timed-out CI runs and tells the agent to read logs, fix, and retry (includes run URLs) |

Both tools share the same flag interface (`--watch`, `--dry-run`, `--repo`, `[pr-number]`).

# Test

- Verified all three CLI tools compile and run successfully via `--dry-run --no-watch`:
  - `npx tsx tools/gh-automation/approve-workflow.ts --dry-run --no-watch`
  - `npx tsx tools/gh-automation/sync-main.ts --dry-run --no-watch`
  - `npx tsx tools/gh-automation/nudge.ts --dry-run --no-watch`
- No unit tests added (consistent with existing `approve-workflow` — no test infra for `gh-automation/` yet)