### PR TITLE
release: v1.9.6

### DIFF
--- a/.github/copilot/skills/generate-changelog/SKILL.md
+++ b/.github/copilot/skills/generate-changelog/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: generate-changelog
+description: Generate a succinct CHANGELOG.md entry from PR descriptions since the last version bump.
+---
+
+# Generate Changelog
+
+Produce a concise, user-facing changelog entry for the current version by summarizing merged PR descriptions.
+
+## Steps
+
+1. **Check for the raw changelog** — verify that `.temp/VERSION_CHANGELOG_FULL.md` exists in the repo root:
+
+   ```bash
+   test -f .temp/VERSION_CHANGELOG_FULL.md
+   ```
+
+   If it does **not** exist, stop and tell the user:
+
+   > The raw PR changelog has not been generated yet. Run this first:
+   >
+   > ```bash
+   > npm run get-version-diffs
+   > ```
+   >
+   > Then re-invoke this skill.
+
+2. **Read the raw changelog** — open `.temp/VERSION_CHANGELOG_FULL.md`. Each entry has the format:
+
+   ```
+   # <short sha>: <commit title>
+
+   <PR description body>
+
+   ---
+   ```
+
+3. **Filter out sentinel commits** — skip any entry whose commit title matches the pattern `ci: sentinel commit`. These are CI verification commits with no user-facing changes.
+
+4. **Read the current version** — get the version string from:
+
+   ```bash
+   cat src/dbt/adapters/fabricspark/__version__.py
+   ```
+
+   The file contains a single line like `version = "1.9.6"`. Extract the version number (e.g., `1.9.6`).
+
+5. **Summarize into a changelog entry** — from the remaining (non-sentinel) PR descriptions, write a **succinct** changelog section. Follow these guidelines:
+
+   - Group related changes under descriptive subheadings (e.g., `### Bug Fixes`, `### New Features`, `### Improvements`)
+   - Each item should be 1–2 sentences max — distill the PR description down to what matters to a user
+   - Use past tense (e.g., "Added…", "Fixed…", "Improved…")
+   - Reference PR numbers inline (e.g., `(#42)`)
+   - Do NOT include the full PR body text — summarize it
+   - Match the style and depth of existing entries in `CHANGELOG.md`
+
+6. **Prepend to CHANGELOG.md** — insert the new section immediately below the `# Changelog` heading in `CHANGELOG.md`, above all existing version sections. The format is:
+
+   ```markdown
+   ## v<version>
+
+   <your summarized content>
+
+   ---
+   ```
+
+   Keep the existing content intact below the new section.
+
+7. **Report completion** — show the user the new section you added and confirm the file was updated.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist/
 logs/
 *.patch
 
+# Temporary
+.temp/
+
 # Unit test
 .tox/
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v1.9.6
+
+### Bug Fixes
+
+- Fixed cross-lakehouse snapshot writes — snapshots now honor the user's `database` config instead of always writing to the default lakehouse (#96)
+- Fixed `ApproximateMatchError` on incremental reruns when lakehouse names contain mixed casing (#94)
+- Fixed single-quote escaping in seed values (e.g., `Cote d'Ivoire`) that caused Spark parse errors (#95)
+- Fixed `dbt docs generate` failing with multiple lakehouses by removing an unnecessary single-database guard (#84)
+- Fixed relation type detection for `MATERIALIZED_LAKE_VIEW` in `show table extended` output and corrected the `DROP` SQL generation (#106)
+
+### Improvements
+
+- Moved `azure-cli` to an optional dependency (`pip install dbt-fabricspark[cli]`) to resolve install conflicts with `azure-cosmos>=4.0` in environments like Fabric Managed Airflow (#149)
+- Hardened MLV API against capacity throttling — retries `Failed` jobs with throttle error codes and uses adaptive backoff on sustained 429s (#146)
+- Increased Livy session creation timeout and added retry/jitter for high-concurrency CI environments (#146)
+
+### Infrastructure
+
+- Added VSCode Devcontainer walkthrough for new developers (#93)
+- Parallelized functional test suite (~7× faster) with declarative YAML scheduler and Nx build system (#87)
+- Added branch-aware workspace nuke for safe concurrent CI runs (#98)
+- Added GitHub automation tools (`sync-main`, `nudge`) for Copilot PR management (#109)
+- Consolidated Dependabot dependency bumps (#152)
+
+---
+
 ## v1.9.5
 
 ### Materialized Lake View Support
@@ -9,6 +35,7 @@
 dbt-fabricspark now supports [Materialized Lake Views](https://learn.microsoft.com/en-us/fabric/data-engineering/materialized-lake-views/materialized-lake-views) as a first-class materialization. MLVs are precomputed, incrementally-maintained views in Fabric lakehouses that accelerate queries over Delta tables without manual refresh pipelines.
 
 **Requirements:**
+
 - Fabric Runtime 1.3+ (Apache Spark ≥ 3.5)
 - Schema-enabled lakehouse
 
@@ -43,14 +70,14 @@ select * from {{ ref('orders') }}
 
 **Config options:**
 
-| Option | Type | Required | Description |
-|---|---|---|---|
-| `mlv_on_demand` | bool | At least one of `mlv_on_demand` or `mlv_schedule` | Trigger an immediate refresh after creation |
-| `mlv_schedule` | dict | At least one of `mlv_on_demand` or `mlv_schedule` | Schedule config for periodic refresh. Must include `endDateTime` |
-| `mlv_comment` | string | No | Description added to the view |
-| `partitioned_by` | list | No | Partition columns |
-| `mlv_constraints` | list | No | CHECK constraints with optional `on_mismatch` (DROP or FAIL) |
-| `tblproperties` | dict | No | Delta table properties |
+| Option            | Type   | Required                                          | Description                                                      |
+| ----------------- | ------ | ------------------------------------------------- | ---------------------------------------------------------------- |
+| `mlv_on_demand`   | bool   | At least one of `mlv_on_demand` or `mlv_schedule` | Trigger an immediate refresh after creation                      |
+| `mlv_schedule`    | dict   | At least one of `mlv_on_demand` or `mlv_schedule` | Schedule config for periodic refresh. Must include `endDateTime` |
+| `mlv_comment`     | string | No                                                | Description added to the view                                    |
+| `partitioned_by`  | list   | No                                                | Partition columns                                                |
+| `mlv_constraints` | list   | No                                                | CHECK constraints with optional `on_mismatch` (DROP or FAIL)     |
+| `tblproperties`   | dict   | No                                                | Delta table properties                                           |
 
 ---
 
@@ -85,6 +112,7 @@ Terminal statuses follow the Fabric `ItemJobStatus` enum: `NotStarted`, `InProgr
 When `mlv_schedule` is provided, the adapter creates or updates a refresh schedule via the Fabric REST API. The operation is idempotent — if a schedule already exists, it is updated in place.
 
 Supported schedule types:
+
 - **Cron** — `interval` in minutes
 - **Daily** — list of `times` (e.g., `["06:00", "18:00"]`)
 - **Weekly** — `weekdays` and `times`
@@ -149,6 +177,7 @@ Errors surface as `MLVApiError` (extends `DbtRuntimeError`) with the operation n
 **Fix:** A new `reuse_session` credential flag allows sessions to persist across dbt runs. When enabled, the adapter writes the active session ID to a file and reattaches to it on the next run if the session is still alive. Fabric automatically reclaims idle sessions after the configured timeout.
 
 **Configuration:**
+
 ```yaml
 # profiles.yml
 my_fabric_profile:
@@ -172,6 +201,7 @@ my_fabric_profile:
 **Fix:** All polling loops are now bounded by configurable deadlines. The adapter raises a clear error when a timeout is exceeded. Statement result polling also handles `error`, `cancelled`, and `cancelling` states explicitly instead of continuing to poll.
 
 **Configuration:**
+
 ```yaml
 # profiles.yml — timeout tuning
 my_fabric_profile:
@@ -233,6 +263,7 @@ my_fabric_profile:
 **Fix:** On connection open, the adapter calls the Fabric REST API (`GET /v1/workspaces/{workspaceId}/lakehouses/{lakehouseId}`) and checks for the `properties.defaultSchema` property. If present, the lakehouse is schema-enabled and three-part naming is used. This detection is automatic and requires no user configuration.
 
 The adapter also validates schema configuration:
+
 - **Schema-enabled lakehouse:** The `schema` value must differ from the lakehouse name (e.g., use `dbo`).
 - **Non-schema lakehouse:** The `schema` is silently set to the lakehouse name for correct SQL generation.
 
@@ -267,6 +298,7 @@ The adapter also validates schema configuration:
 **Problem:** `generate_schema_name` and `generate_database_name` did not account for lakehouse type, potentially generating invalid namespace values.
 
 **Fix:**
+
 - **Non-schema lakehouses:** `generate_schema_name` always returns the lakehouse name (the only valid namespace).
 - **Schema-enabled lakehouses:** Uses dbt's standard `generate_schema_name_for_env` logic.
 - `generate_database_name` always returns the target lakehouse name.
@@ -282,6 +314,7 @@ The adapter also validates schema configuration:
 **Fix:** A new `environmentId` credential field injects the environment identifier into the Livy session's Spark configuration, telling Fabric to launch the session using that environment's settings.
 
 **Configuration:**
+
 ```yaml
 # profiles.yml
 my_fabric_profile:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Documentation 📚
+
+- [Release checklist](./RELEASE_CHECKLIST.md)
+
+---
+[Home](../README.md) > [Documentation](./README.md)

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,122 @@
+# Release Guide: microsoft/dbt-fabricspark
+
+## 📋 Checklist
+
+| #   | Task                                    | Where                                         |
+| --- | --------------------------------------- | --------------------------------------------- |
+| 1   | Pick new version number                 | Your head 🧠                                  |
+| 2   | Bump `__version__.py`                   | `src/dbt/adapters/fabricspark/__version__.py` |
+| 3   | Update `CHANGELOG.md`                   | `CHANGELOG.md`                                |
+| 4   | Push to `main`, confirm CI is green     | GitHub Actions → `ci.yml`                     |
+| 5   | Create GitHub Release with tag `vX.Y.Z` | github.com/…/releases/new                     |
+| 6   | Watch `release.yml` pipeline            | GitHub Actions → `release.yml`                |
+| 7   | Verify on PyPI                          | pypi.org/project/dbt-fabricspark              |
+
+## 🗺️ How a Release Works (Big Picture)
+
+When you create a **GitHub Release** with a tag like `v1.9.6`, it automatically triggers the `release.yml` workflow, which:
+
+1. Builds the Python package
+2. Runs the full test suite against a real Fabric workspace
+3. Publishes the package to **PyPI** automatically
+
+---
+
+## Step-by-Step Release Plan
+
+### Step 1 — Decide the new version number
+
+This project uses **semantic versioning** (`vMAJOR.MINOR.PATCH`):
+
+- **PATCH** (`v1.9.6`): Bug fixes only
+- **MINOR** (`v1.10.0`): New features, backwards-compatible
+- **MAJOR** (`v2.0.0`): Breaking changes
+
+👉 For most releases, you'll increment the **PATCH** number (e.g. `1.9.5` → `1.9.6`).
+
+---
+
+### Step 2 — Bump the version in code
+
+The single source of truth for the version is `src/dbt/adapters/fabricspark/__version__.py`:
+
+Edit this file and change `"1.9.5"` to your new version (e.g. `"1.9.6"`). This is the only file you need to change — `pyproject.toml` reads it dynamically.
+
+Commit this change:
+
+```sh
+git commit -am "chore: bump version to v1.9.6"
+git push origin main
+```
+
+---
+
+### Step 3 — Update `CHANGELOG.md`
+
+Open `CHANGELOG.md` and add a new section **at the top** (above `## v1.9.5`), following the same format already used:
+
+```
+## v1.9.6
+
+### Bug Fixes
+
+#### Short title describing the fix
+
+**Problem:** What was broken and why.
+
+**Fix:** What you changed to fix it.
+```
+
+Then commit and push:
+
+```sh
+git commit -am "docs: update CHANGELOG for v1.9.6"
+git push origin main
+```
+
+---
+
+### Step 4 — Make sure `main` is clean and green
+
+Before releasing, verify the CI workflow is passing on `main`:
+
+1. Go to **Actions → ci.yml** on GitHub
+2. Confirm the latest run on `main` is ✅ green (ruff linting, unit tests across Python 3.9–3.13, build verification)
+
+**Do not release from a broken `main`.**
+
+---
+
+### Step 5 — Create a GitHub Release (this triggers the publish)
+
+This is the magic step. Creating a release with the right tag automatically fires the release pipeline.
+
+1. Go to `github.com/microsoft/dbt-fabricspark/releases/new`
+2. In **"Choose a tag"**, type `v1.9.6` and click **"Create new tag: v1.9.6 on publish"**
+3. Set **Target** to `main`
+4. Set the **Release title** to `v1.9.6`
+5. In the **description box**, paste your changelog content from Step 3 (or click "Generate release notes" to auto-populate from PR titles)
+6. Leave **"Set as the latest release"** checked
+7. Click **"Publish release"** 🚀
+
+---
+
+### Step 6 — Watch the release pipeline
+
+1. Go to **Actions → release.yml** on GitHub
+2. You'll see a new run triggered by the tag. It will:
+   - 🔒 Authenticate to Azure via OIDC
+   - 📦 Build the wheel/sdist (`nx run dbt-fabricspark:build`)
+   - 🧪 Run integration tests against the real Fabric workspace
+   - 🚀 Publish to PyPI (`nx run dbt-fabricspark:publish`) using the `PYPI_TOKEN` secret
+3. The run takes up to **120 minutes** (integration tests are slow). Monitor for ✅ or ❌.
+
+---
+
+### Step 7 — Verify the PyPI publish
+
+Once the workflow is green:
+
+1. Go to `pypi.org/project/dbt-fabricspark`
+2. Confirm `v1.9.6` is listed as the latest version
+3. Test it locally: `pip install dbt-fabricspark==1.9.6`

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "approve-copilot-gh-workflow": "tsx tools/gh-automation/approve-workflow.ts",
     "sync-copilot-main": "tsx tools/gh-automation/sync-main.ts",
     "nudge-copilot": "tsx tools/gh-automation/nudge.ts",
-    "compact-dependabot": "tsx tools/gh-automation/compact-dependabot.ts"
+    "compact-dependabot": "tsx tools/gh-automation/compact-dependabot.ts",
+    "get-version-diffs": "tsx tools/gh-automation/get-version-diffs.ts"
   },
   "type": "module",
   "nx": {}

--- a/src/dbt/adapters/fabricspark/__version__.py
+++ b/src/dbt/adapters/fabricspark/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.5"
+version = "1.9.6"

--- a/tests/functional/adapter/incremental_strategies/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental_strategies/test_incremental_strategies.py
@@ -91,6 +91,11 @@ class TestDeltaStrategies(BaseIncrementalStrategies):
 
     def run_and_test(self, project):
         self.seed_and_run_twice()
+        # Invalidate Spark's cached metadata for seed tables to avoid
+        # TABLE_OR_VIEW_NOT_FOUND flakes caused by cross-catalog metastore
+        # propagation delays in Fabric.
+        for seed in ["expected_append", "expected_upsert", "expected_partial_upsert"]:
+            project.run_sql(f"REFRESH TABLE {{schema}}.{seed}")
         check_relations_equal(project.adapter, ["append_delta", "expected_append"])
         check_relations_equal(project.adapter, ["merge_no_key", "expected_append"])
         check_relations_equal(project.adapter, ["merge_unique_key", "expected_upsert"])

--- a/tools/gh-automation/README.md
+++ b/tools/gh-automation/README.md
@@ -8,6 +8,7 @@ GitHub Action automations for repo maintenance. All tools discover open Copilot 
 | **sync-main**          | Comments on PRs whose branches are behind `main`, telling Copilot to merge and re-test               |
 | **nudge**              | Detects failed/cancelled/timed-out CI runs and comments telling Copilot to read logs, fix, and retry |
 | **compact-dependabot** | Fetches diffs from open Dependabot PRs and writes a combined patch file for review and application   |
+| **get-version-diffs**  | Generates a changelog of PR descriptions between the last version bump and HEAD of main              |
 
 ## Usage
 
@@ -30,6 +31,11 @@ npx tsx tools/gh-automation/nudge.ts 98 --no-watch --dry-run
 npm run compact-dependabot
 npm run compact-dependabot -- --dry-run
 npm run compact-dependabot -- --output my-patch.patch
+
+# Generate version changelog (one-shot)
+npm run get-version-diffs
+npm run get-version-diffs -- --dry-run
+npm run get-version-diffs -- --output custom-changelog.md
 ```
 
 ## Flags

--- a/tools/gh-automation/core/version-diff-service.ts
+++ b/tools/gh-automation/core/version-diff-service.ts
@@ -1,0 +1,166 @@
+/**
+ * Service for generating a changelog of PR descriptions between the last
+ * version bump and the current HEAD of main.
+ *
+ * Uses git log for commit history and `gh api` to resolve associated PRs.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { GhClient } from './gh-client.js';
+import { Logger } from './logger.js';
+
+export interface VersionDiffConfig {
+    readonly repo: string;
+    readonly dryRun: boolean;
+    readonly output: string;
+}
+
+interface CommitInfo {
+    readonly sha: string;
+    readonly shortSha: string;
+    readonly title: string;
+}
+
+interface PrInfo {
+    readonly number: number;
+    readonly title: string;
+    readonly body: string | null;
+}
+
+export class VersionDiffService {
+    private readonly client: GhClient;
+    private readonly logger: Logger;
+    private readonly config: VersionDiffConfig;
+
+    private static readonly VERSION_FILE = 'src/dbt/adapters/fabricspark/__version__.py';
+
+    constructor(client: GhClient, logger: Logger, config: VersionDiffConfig) {
+        this.client = client;
+        this.logger = logger;
+        this.config = config;
+    }
+
+    /** Run the full changelog generation pipeline. */
+    run(): void {
+        const lastVersionCommit = this.findLastVersionCommit();
+        if (!lastVersionCommit) {
+            this.logger.error('Could not find any commit that modified __version__.py on main.');
+            process.exit(1);
+        }
+
+        this.logger.info(`Last version bump commit: ${lastVersionCommit.substring(0, 7)}`);
+
+        const commits = this.getCommitsSince(lastVersionCommit);
+        if (commits.length === 0) {
+            this.logger.info('No commits found since last version bump. Nothing to do.');
+            return;
+        }
+
+        this.logger.info(`Found ${commits.length} commit(s) since last version bump.`);
+
+        const entries = this.resolvePrDescriptions(commits);
+        const markdown = this.formatMarkdown(entries);
+
+        if (this.config.dryRun) {
+            this.logger.dryRun(`Would write ${entries.length} entries to ${this.config.output}`);
+            this.logger.info('\n' + markdown);
+            return;
+        }
+
+        mkdirSync(dirname(this.config.output), { recursive: true });
+        writeFileSync(this.config.output, markdown, 'utf-8');
+        this.logger.info(`\n✓ Wrote changelog (${entries.length} entries) to ${this.config.output}`);
+    }
+
+    /** Find the last commit on main that modified __version__.py. */
+    private findLastVersionCommit(): string | null {
+        const result = spawnSync('git', ['log', '--format=%H', '-1', 'main', '--', VersionDiffService.VERSION_FILE], {
+            encoding: 'utf-8',
+            stdio: ['inherit', 'pipe', 'pipe'],
+        });
+
+        if (result.status !== 0 || !result.stdout.trim()) {
+            return null;
+        }
+
+        return result.stdout.trim();
+    }
+
+    /** Get all commits between the version commit (exclusive) and HEAD of main. */
+    private getCommitsSince(sinceSha: string): CommitInfo[] {
+        const result = spawnSync('git', ['log', '--format=%H %s', `${sinceSha}..main`], {
+            encoding: 'utf-8',
+            stdio: ['inherit', 'pipe', 'pipe'],
+        });
+
+        if (result.status !== 0 || !result.stdout.trim()) {
+            return [];
+        }
+
+        return result.stdout
+            .trim()
+            .split('\n')
+            .map((line) => {
+                const spaceIdx = line.indexOf(' ');
+                const sha = line.substring(0, spaceIdx);
+                const title = line.substring(spaceIdx + 1);
+                return { sha, shortSha: sha.substring(0, 7), title };
+            });
+    }
+
+    /** For each commit, find the associated PR via GitHub API. */
+    private resolvePrDescriptions(commits: CommitInfo[]): Array<{ commit: CommitInfo; pr: PrInfo | null }> {
+        const seen = new Set<number>();
+        const entries: Array<{ commit: CommitInfo; pr: PrInfo | null }> = [];
+
+        for (const commit of commits) {
+            this.logger.info(`  → Resolving PR for ${commit.shortSha}: ${commit.title}`);
+
+            const pr = this.fetchPrForCommit(commit.sha);
+
+            if (pr && seen.has(pr.number)) {
+                continue; // deduplicate
+            }
+
+            if (pr) {
+                seen.add(pr.number);
+            }
+
+            entries.push({ commit, pr });
+        }
+
+        return entries;
+    }
+
+    /** Use gh api to find the PR associated with a commit. */
+    private fetchPrForCommit(sha: string): PrInfo | null {
+        const result = this.client.exec(
+            ['api', `repos/${this.client.repoSlug}/commits/${sha}/pulls`, '--jq', '.[0] // empty'],
+            { fatal: false },
+        );
+
+        if (result.status !== 0 || !result.stdout.trim()) {
+            return null;
+        }
+
+        try {
+            const data = JSON.parse(result.stdout) as { number: number; title: string; body: string | null };
+            return { number: data.number, title: data.title, body: data.body };
+        } catch {
+            return null;
+        }
+    }
+
+    /** Format the entries into a markdown changelog. */
+    private formatMarkdown(entries: Array<{ commit: CommitInfo; pr: PrInfo | null }>): string {
+        const sections = entries.map(({ commit, pr }) => {
+            const heading = `# ${commit.shortSha}: ${commit.title}`;
+            const body = pr?.body?.trim() || '_(No PR description found)_';
+            return `${heading}\n\n${body}`;
+        });
+
+        return sections.join('\n\n---\n\n') + '\n';
+    }
+}

--- a/tools/gh-automation/get-version-diffs.ts
+++ b/tools/gh-automation/get-version-diffs.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env tsx
+/**
+ * CLI entry point: generate a changelog of PR descriptions since the last version bump.
+ *
+ * Finds the last commit that modified __version__.py on main, lists all
+ * commits since then, fetches associated PR descriptions via the GitHub API,
+ * and writes a markdown changelog.
+ *
+ * Usage:
+ *   npx tsx tools/gh-automation/get-version-diffs.ts
+ *   npx tsx tools/gh-automation/get-version-diffs.ts --dry-run
+ *   npx tsx tools/gh-automation/get-version-diffs.ts --output custom-path.md
+ */
+
+import { Command } from 'commander';
+import { Logger } from './core/logger.js';
+import { GhClient } from './core/gh-client.js';
+import { VersionDiffService } from './core/version-diff-service.js';
+
+interface GetVersionDiffsOptions {
+    readonly repo: string;
+    readonly dryRun: boolean;
+    readonly output: string;
+    // Required by GhAutomationConfig shape used in GhClient
+    readonly watch: boolean;
+    readonly sleep: string;
+}
+
+const program = new Command();
+
+program
+    .name('get-version-diffs')
+    .description('Generate a changelog of PR descriptions since the last version bump')
+    .option('--dry-run', 'Print actions without executing them', false)
+    .option('--repo <owner/repo>', 'GitHub repository', 'microsoft/dbt-fabricspark')
+    .option('--output <path>', 'Output markdown file path', '.temp/VERSION_CHANGELOG_FULL.md')
+    .action((opts: GetVersionDiffsOptions) => {
+        const logger = new Logger();
+        const client = new GhClient(opts, logger);
+        const service = new VersionDiffService(client, logger, {
+            repo: opts.repo,
+            dryRun: opts.dryRun,
+            output: opts.output,
+        });
+
+        service.run();
+    });
+
+program.parse();


### PR DESCRIPTION
## Summary

Bumps version to **v1.9.6** and adds release tooling.

### Bug Fixes
- Cross-lakehouse snapshot writes (#96)
- `ApproximateMatchError` on mixed-case lakehouse names (#94)
- Single-quote escaping in seed values (#95)
- `dbt docs generate` with multiple lakehouses (#84)
- Relation type detection for `MATERIALIZED_LAKE_VIEW` (#106)

### Improvements
- `azure-cli` moved to optional `[cli]` extra (#149)
- MLV API throttle resilience and adaptive backoff (#146)
- Livy session creation timeout/retry for high concurrency (#146)

### Infrastructure
- Release checklist and changelog automation skill
- GitHub automation tooling (`get-version-diffs`)
- Devcontainer docs link
