### PR TITLE
fix: Remove Az Login deps from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,29 +40,8 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: "🔒 Auth: Azure login with OIDC"
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
-        with:
-          client-id: ${{ secrets.APP_ID }}
-          tenant-id: ${{ secrets.TENANT_ID }}
-          allow-no-subscriptions: true
-
-      - name: "📝 Write test.env"
-        run: |
-          echo "WORKSPACE_ID=${{ secrets.WORKSPACE_ID }}" > "$GITHUB_WORKSPACE/test.env"
-          echo "LIVY_ENDPOINT=https://msitapi.fabric.microsoft.com/v1" >> "$GITHUB_WORKSPACE/test.env"
-
-      - name: "⚙️ Post create commands"
-        run: /tmp/overlay/post-create-commands.sh
-
-      - name: "⚙️ Post attach commands"
-        run: /tmp/overlay/post-attach-commands.sh
-
       - name: "📦 Build"
         run: npx nx run dbt-fabricspark:build --output-style=stream --verbose
-
-      - name: "🧪 Test"
-        run: npx nx run dbt-fabricspark:test --output-style=stream --verbose
 
       - name: "🚀 Publish"
         run: npx nx run dbt-fabricspark:publish --output-style=stream --verbose

--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,22 @@
+{
+   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+   "namedInputs": {
+      "default": [
+         "{projectRoot}/**/*",
+         "!{projectRoot}/.github/**/*",
+         "!{projectRoot}/**/*.md"
+      ],
+      "production": ["default"]
+   },
+   "targetDefaults": {
+      "build": {
+         "inputs": ["production"]
+      },
+      "lint": {
+         "inputs": ["default"]
+      },
+      "test": {
+         "inputs": ["default"]
+      }
+   }
+}


### PR DESCRIPTION
## Summary

Removes Azure Login OIDC authentication, test.env generation, post-create/post-attach commands, and test step from the release workflow. The release pipeline now only builds and publishes.

## Changes

- Removed Azure login with OIDC step
- Removed `test.env` file generation step
- Removed post-create and post-attach command steps
- Removed test step

This simplifies the release workflow by removing dependencies that are not needed for building and publishing the package.