### PR TITLE
fix(livysession): handle optional fields in Fabric Livy SessionResponse

### DIFF
--- a/src/dbt/adapters/fabricspark/livysession.py
+++ b/src/dbt/adapters/fabricspark/livysession.py
@@ -543,9 +543,32 @@ class LivySession:
                 headers=get_headers(self.credential, False),
                 timeout=self.credential.http_timeout,
             )
+
+            # Fabric returns HTTP 430 (non-standard) — and sometimes 429 —
+            # when the capacity has too many concurrent Spark sessions. The
+            # body is an ErrorResponse (errorCode + message), not a
+            # SessionResponse, so without explicit handling
+            # ``raise_for_status()`` below would raise an ``HTTPError``
+            # which the legacy ``except HTTPError`` arm wraps as a generic
+            # ``Exception("Http Error: ", err_detail)``. That hides the
+            # rate-limit nature from the user (and from any retry logic
+            # that might want to back off). Surface a clearer error
+            # explicitly instead.
+            if response.status_code in (429, 430):
+                raise FailedToConnectError(
+                    f"Fabric Spark rate limit (HTTP {response.status_code}): "
+                    f"too many concurrent Spark sessions on this capacity. "
+                    f"Cancel active jobs in the Fabric Monitoring Hub, "
+                    f"use a larger capacity SKU, or try again later. "
+                    f"Tip: set ``reuse_session: true`` in profiles.yml so dbt "
+                    f"shares an existing session across runs."
+                )
+
             if response.status_code == 200 or response.status_code == 201:
                 logger.debug("Initiated Livy Session...")
             response.raise_for_status()
+        except FailedToConnectError:
+            raise
         except requests.exceptions.ConnectionError as c_err:
             err_detail = c_err.response.json() if c_err.response else str(c_err)
             raise Exception("Connection Error :", err_detail)
@@ -566,9 +589,24 @@ class LivySession:
 
         self.session_id = None
         try:
-            self.session_id = str(response.json()["id"])
-        except requests.exceptions.JSONDecodeError as json_err:
-            raise Exception("Json decode error to get session_id") from json_err
+            res_body = response.json()
+        except (requests.exceptions.JSONDecodeError, ValueError) as json_err:
+            raise FailedToConnectError(
+                f"Cannot parse session creation response from Fabric Livy API: "
+                f"{response.text[:500]}"
+            ) from json_err
+
+        # Per the Fabric Livy SessionResponse swagger contract, ``id`` is an
+        # optional field — clients must not assume it is present. Use
+        # ``dict.get`` so a missing ``id`` raises a clear ``FailedToConnectError``
+        # instead of an opaque ``KeyError('id')``.
+        session_id = res_body.get("id")
+        if session_id is None:
+            raise FailedToConnectError(
+                f"Session creation response has no 'id' field. "
+                f"Response: {json.dumps(res_body)[:500]}"
+            )
+        self.session_id = str(session_id)
 
         # Wait for the session to start
         self.wait_for_session_start()
@@ -577,7 +615,26 @@ class LivySession:
         return self.session_id
 
     def wait_for_session_start(self) -> None:
-        """Wait for the Livy session to reach the 'idle' state."""
+        """Wait for the Livy session to reach the 'idle' state.
+
+        Per the Fabric Livy SessionResponse swagger contract, every state
+        field is optional. A SessionResponse may legitimately arrive with:
+
+          - ``state`` (top-level Livy state) — present once Livy mints the
+            session; absent during the early Fabric acquisition window
+          - ``livyInfo.currentState`` — appears once the Spark driver is
+            provisioned; lags ``state`` slightly
+          - ``fabricSessionStateInfo.state`` — Fabric-side acquisition state
+            (``queued`` / ``acquiringSession`` / ``error`` / ``cancelled`` /
+            ...). This is the **earliest** signal of a provisioning failure
+            and is the only field populated when Fabric rejects the request
+            outright (e.g. capacity unavailable).
+
+        On HTTP 4xx/5xx the body is an ``ErrorResponse`` (``errorCode`` +
+        ``message``), not a ``SessionResponse`` — none of the state fields
+        exist at all. Always check the HTTP status before parsing as
+        SessionResponse.
+        """
         deadline = time.time() + self.credential.session_start_timeout
         while True:
             if time.time() > deadline:
@@ -585,11 +642,44 @@ class LivySession:
                     f"Timeout ({self.credential.session_start_timeout}s) waiting for session "
                     f"{self.session_id} to start. Increase `session_start_timeout` in profiles.yml."
                 )
-            res = requests.get(
+            http_res = requests.get(
                 self.connect_url + "/sessions/" + self.session_id,
                 headers=get_headers(self.credential, False),
                 timeout=self.credential.http_timeout,
-            ).json()
+            )
+
+            # Non-2xx: body is an ErrorResponse, not a SessionResponse. Only
+            # fail fast on codes where retry cannot help — auth/permission
+            # (401, 403) or "session no longer exists" (410). Other 4xx/5xx
+            # (including transient 404s on the session endpoint during early
+            # acquisition, and 5xx from Fabric infra blips) fall through to
+            # the polling loop so the existing ``session_start_timeout``
+            # bounds them — same tolerance the legacy code path provided.
+            if http_res.status_code in (401, 403, 410):
+                try:
+                    err_body = http_res.json()
+                    err_code = err_body.get("errorCode", "")
+                    err_msg = err_body.get("message", "")
+                except (requests.exceptions.JSONDecodeError, ValueError):
+                    err_code = f"HTTP {http_res.status_code}"
+                    err_msg = http_res.text[:500]
+                raise FailedToConnectError(
+                    f"Failed to poll session {self.session_id}: {err_code} — {err_msg}"
+                )
+
+            if http_res.status_code >= 400:
+                # Transient: log and keep polling. The body is an
+                # ErrorResponse with no state fields, so calling .json() on
+                # it and falling through to the state-check branches below
+                # would just see empty strings and sleep — same effect.
+                logger.debug(
+                    f"Session {self.session_id} poll got HTTP "
+                    f"{http_res.status_code}, retrying after poll_wait..."
+                )
+                time.sleep(self.credential.poll_wait)
+                continue
+
+            res = http_res.json()
 
             # Local Livy uses "state" directly, Fabric uses "livyInfo.currentState"
             if self.is_local_mode:
@@ -604,27 +694,67 @@ class LivySession:
                     logger.error("ERROR, cannot create a livy session")
                     raise FailedToConnectError("failed to connect")
             else:
-                # Fabric Livy: check top-level state first
-                # When session is starting, "livyInfo" may not exist yet
+                # Fabric Livy: three optional state levels per swagger.
                 top_level_state = res.get("state", "")
-                livy_info = res.get("livyInfo", {})
+                livy_info = res.get("livyInfo") or {}
                 livy_state = livy_info.get("currentState", "")
+                fabric_info = res.get("fabricSessionStateInfo") or {}
+                fabric_state = fabric_info.get("state", "")
+
+                # Fabric-side acquisition failure (earliest signal — fires
+                # before Livy state appears). Capturing this avoids the
+                # silent multi-minute timeout users hit today when capacity
+                # rejection arrives via fabricSessionStateInfo only.
+                if fabric_state in ("error", "cancelled"):
+                    error_info = res.get("errorInfo") or []
+                    err_detail = (
+                        error_info[0].get("message", "") if error_info else ""
+                    )
+                    raise FailedToConnectError(
+                        f"Fabric failed to acquire Spark session "
+                        f"{self.session_id}. fabricSessionStateInfo.state="
+                        f"{fabric_state}. {err_detail} "
+                        f"Response: {json.dumps(res)[:1000]}"
+                    )
 
                 if top_level_state in ("starting", "not_started"):
                     # Session still starting, continue polling
-                    logger.debug(f"Session {self.session_id} is {top_level_state}, waiting...")
+                    logger.debug(
+                        f"Session {self.session_id} is {top_level_state} "
+                        f"(fabric={fabric_state}), waiting..."
+                    )
                     time.sleep(self.credential.poll_wait)
                 elif livy_state == "idle":
                     logger.debug(f"New livy session id is: {self.session_id}, {res}")
                     self.is_new_session_required = False
                     break
-                elif livy_state == "dead" or top_level_state == "dead":
+                elif top_level_state in (
+                    "dead",
+                    "error",
+                    "killed",
+                    "shutting_down",
+                ) or livy_state in ("dead", "error", "killed", "shutting_down"):
+                    # Terminal state set matches the canonical list accepted
+                    # in PR #65 (microsoft/dbt-fabricspark#65). Surface
+                    # Fabric's ``errorInfo[]`` when present — it carries the
+                    # precise failure reason (``LIVY_JOB_TIMED_OUT``,
+                    # ``CAPACITY_UNAVAILABLE``, ...). Without this, users see
+                    # only the generic "failed to connect".
+                    error_info = res.get("errorInfo") or []
+                    err_detail = (
+                        error_info[0].get("message", "") if error_info else ""
+                    )
                     logger.error("ERROR, cannot create a livy session")
-                    raise FailedToConnectError("failed to connect")
+                    raise FailedToConnectError(
+                        f"Spark session {self.session_id} failed to start. "
+                        f"state={top_level_state}, livy={livy_state}, "
+                        f"fabric={fabric_state}. {err_detail}"
+                    )
                 else:
                     # Unknown state, keep waiting (could be transitioning)
                     logger.debug(
-                        f"Session {self.session_id} in state: top={top_level_state}, livy={livy_state}, waiting..."
+                        f"Session {self.session_id} state: top={top_level_state}, "
+                        f"livy={livy_state}, fabric={fabric_state}, waiting..."
                     )
                     time.sleep(self.credential.poll_wait)
 

--- a/tests/unit/test_livysession_optional_fields.py
+++ b/tests/unit/test_livysession_optional_fields.py
@@ -1,0 +1,297 @@
+"""Tests for defensive parsing of the Fabric Livy SessionResponse.
+
+Per the official Fabric Livy SessionResponse swagger contract, every
+state-related field (``state``, ``livyInfo``, ``fabricSessionStateInfo``,
+``id``, ``errorInfo``) is *optional*. These tests exercise the request
+paths that previously assumed those fields were always present and would
+raise an opaque ``KeyError`` (or silently time out) when they weren't.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dbt.adapters.exceptions import FailedToConnectError
+from dbt.adapters.fabricspark.credentials import FabricSparkCredentials
+from dbt.adapters.fabricspark.livysession import LivySession
+
+
+def _fabric_credentials(**overrides) -> FabricSparkCredentials:
+    """Build a Fabric-mode credential instance suitable for tests."""
+    base = dict(
+        method="livy",
+        livy_mode="fabric",
+        authentication="CLI",
+        workspaceid="1de8390c-9aca-4790-bee8-72049109c0f4",
+        lakehouseid="8c5bc260-bc3a-4898-9ada-01e433d461ba",
+        lakehouse="tests",
+        spark_config={"name": "test-session"},
+        # Keep timeouts tiny so tests stay fast under the polling loop.
+        session_start_timeout=2,
+        poll_wait=0,
+    )
+    base.update(overrides)
+    return FabricSparkCredentials(**base)
+
+
+def _http_response(status: int, body: dict | None = None, text: str = "") -> MagicMock:
+    """Build a mock requests.Response with the given status_code/json()."""
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = body if body is not None else {}
+    resp.text = text
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# create_session — HTTP 429 / 430 rate-limit handling
+# ---------------------------------------------------------------------------
+
+
+@patch("dbt.adapters.fabricspark.livysession.requests.post")
+@patch("dbt.adapters.fabricspark.livysession.get_headers")
+def test_create_session_clear_error_on_http_430(mock_headers, mock_post):
+    """Fabric returns HTTP 430 (non-standard) on Spark capacity overflow.
+    The body is an ErrorResponse, not a SessionResponse, so the legacy
+    ``response.json()["id"]`` lookup raised an opaque KeyError. We expect a
+    clear FailedToConnectError that names the rate limit.
+    """
+    mock_headers.return_value = {"Authorization": "Bearer t"}
+    mock_post.return_value = _http_response(430, {"errorCode": "TooManyRequests"})
+
+    session = LivySession(_fabric_credentials())
+    with pytest.raises(FailedToConnectError, match="rate limit.*HTTP 430"):
+        session.create_session({"name": "test"})
+
+
+@patch("dbt.adapters.fabricspark.livysession.requests.post")
+@patch("dbt.adapters.fabricspark.livysession.get_headers")
+def test_create_session_clear_error_on_http_429(mock_headers, mock_post):
+    """Same path as 430, but for the standard 429 status."""
+    mock_headers.return_value = {"Authorization": "Bearer t"}
+    mock_post.return_value = _http_response(429, {"errorCode": "TooManyRequests"})
+
+    session = LivySession(_fabric_credentials())
+    with pytest.raises(FailedToConnectError, match="rate limit.*HTTP 429"):
+        session.create_session({"name": "test"})
+
+
+# ---------------------------------------------------------------------------
+# create_session — defensive 'id' extraction (id is optional per swagger)
+# ---------------------------------------------------------------------------
+
+
+@patch("dbt.adapters.fabricspark.livysession.requests.post")
+@patch("dbt.adapters.fabricspark.livysession.get_headers")
+def test_create_session_clear_error_when_response_missing_id(mock_headers, mock_post):
+    """SessionResponse.id is optional per the swagger contract. When Fabric
+    returns 200/201 with a body that omits ``id``, surface a clear error
+    instead of letting ``KeyError('id')`` bubble up.
+    """
+    mock_headers.return_value = {"Authorization": "Bearer t"}
+    mock_post.return_value = _http_response(
+        201, {"livyInfo": {"currentState": "starting"}}
+    )
+
+    session = LivySession(_fabric_credentials())
+    with pytest.raises(FailedToConnectError, match="no 'id' field"):
+        session.create_session({"name": "test"})
+
+
+# ---------------------------------------------------------------------------
+# wait_for_session_start — non-2xx response is ErrorResponse, not SessionResponse
+# ---------------------------------------------------------------------------
+
+
+@patch("dbt.adapters.fabricspark.livysession.requests.get")
+@patch("dbt.adapters.fabricspark.livysession.get_headers")
+def test_wait_for_session_start_fails_fast_on_auth_terminal_status(
+    mock_headers, mock_get
+):
+    """On terminal auth/permission codes (401, 403, 410) the body is an
+    ErrorResponse (errorCode + message); retry cannot help. Verify the
+    HTTP status is checked first and the errorCode/message are surfaced
+    immediately (no polling).
+    """
+    mock_headers.return_value = {"Authorization": "Bearer t"}
+    mock_get.return_value = _http_response(
+        401, {"errorCode": "Unauthorized", "message": "Token expired"}
+    )
+
+    session = LivySession(_fabric_credentials())
+    session.session_id = "1"
+    with pytest.raises(FailedToConnectError, match="Unauthorized.*Token expired"):
+        session.wait_for_session_start()
+
+
+@patch("dbt.adapters.fabricspark.livysession.requests.get")
+@patch("dbt.adapters.fabricspark.livysession.get_headers")
+def test_wait_for_session_start_tolerates_transient_4xx(mock_headers, mock_get):
+    """A transient 404 on the session endpoint (Fabric infra blip during
+    early acquisition) must NOT hard-fail — the patch tolerates it the same
+    way the legacy code did, by logging and continuing the polling loop.
+    Verify by returning 404 once then a successful "idle" response.
+    """
+    mock_headers.return_value = {"Authorization": "Bearer t"}
+    mock_get.side_effect = [
+        _http_response(404, {"errorCode": "NotFound", "message": "session not yet visible"}),
+        _http_response(200, {"livyInfo": {"currentState": "idle"}}),
+    ]
+
+    session = LivySession(_fabric_credentials())
+    session.session_id = "1"
+    # Should reach idle on the second poll, not raise.
+    session.wait_for_session_start()
+    assert session.is_new_session_required is False
+    assert mock_get.call_count == 2
+
+
+@patch("dbt.adapters.fabricspark.livysession.requests.get")
+@patch("dbt.adapters.fabricspark.livysession.get_headers")
+def test_wait_for_session_start_tolerates_transient_5xx(mock_headers, mock_get):
+    """A transient 503 from Fabric infra blip must not hard-fail — same
+    tolerance class as 404.
+    """
+    mock_headers.return_value = {"Authorization": "Bearer t"}
+    mock_get.side_effect = [
+        _http_response(503, {"errorCode": "ServiceUnavailable"}),
+        _http_response(200, {"livyInfo": {"currentState": "idle"}}),
+    ]
+
+    session = LivySession(_fabric_credentials())
+    session.session_id = "1"
+    session.wait_for_session_start()
+    assert mock_get.call_count == 2
+
+
+@patch("dbt.adapters.fabricspark.livysession.requests.get")
+@patch("dbt.adapters.fabricspark.livysession.get_headers")
+def test_wait_for_session_start_includes_shutting_down_as_terminal(
+    mock_headers, mock_get
+):
+    """Per the canonical terminal-state set accepted in PR #65,
+    ``shutting_down`` is a terminal state. Treating it as transient would
+    cause the poller to burn the full ``session_start_timeout`` window
+    waiting for a session that's being torn down.
+    """
+    mock_headers.return_value = {"Authorization": "Bearer t"}
+    mock_get.return_value = _http_response(
+        200,
+        {
+            "state": "shutting_down",
+            "livyInfo": {"currentState": "shutting_down"},
+            "errorInfo": [
+                {"errorCode": "SessionShuttingDown", "message": "Session terminated"}
+            ],
+        },
+    )
+
+    session = LivySession(_fabric_credentials())
+    session.session_id = "1"
+    with pytest.raises(FailedToConnectError, match="Session terminated"):
+        session.wait_for_session_start()
+
+
+# ---------------------------------------------------------------------------
+# wait_for_session_start — fabricSessionStateInfo is the earliest failure signal
+# ---------------------------------------------------------------------------
+
+
+@patch("dbt.adapters.fabricspark.livysession.requests.get")
+@patch("dbt.adapters.fabricspark.livysession.get_headers")
+def test_wait_for_session_start_detects_fabric_state_error(mock_headers, mock_get):
+    """During Fabric-side acquisition, only fabricSessionStateInfo is
+    populated; state and livyInfo are absent. Without checking
+    fabricSessionStateInfo, capacity-rejection failures cause a silent
+    multi-minute timeout.
+    """
+    mock_headers.return_value = {"Authorization": "Bearer t"}
+    mock_get.return_value = _http_response(
+        200,
+        {"fabricSessionStateInfo": {"state": "error"}},
+    )
+
+    session = LivySession(_fabric_credentials())
+    session.session_id = "1"
+    with pytest.raises(
+        FailedToConnectError,
+        match="fabricSessionStateInfo.state=error",
+    ):
+        session.wait_for_session_start()
+
+
+@patch("dbt.adapters.fabricspark.livysession.requests.get")
+@patch("dbt.adapters.fabricspark.livysession.get_headers")
+def test_wait_for_session_start_detects_fabric_state_cancelled(mock_headers, mock_get):
+    """``cancelled`` is the second terminal value Fabric uses for
+    ``fabricSessionStateInfo.state`` (e.g. when a parallel run cancels the
+    acquisition request).
+    """
+    mock_headers.return_value = {"Authorization": "Bearer t"}
+    mock_get.return_value = _http_response(
+        200,
+        {"fabricSessionStateInfo": {"state": "cancelled"}},
+    )
+
+    session = LivySession(_fabric_credentials())
+    session.session_id = "1"
+    with pytest.raises(
+        FailedToConnectError,
+        match="fabricSessionStateInfo.state=cancelled",
+    ):
+        session.wait_for_session_start()
+
+
+# ---------------------------------------------------------------------------
+# wait_for_session_start — errorInfo[] surfaces concrete failure reasons
+# ---------------------------------------------------------------------------
+
+
+@patch("dbt.adapters.fabricspark.livysession.requests.get")
+@patch("dbt.adapters.fabricspark.livysession.get_headers")
+def test_wait_for_session_start_surfaces_errorInfo_on_dead(mock_headers, mock_get):
+    """When Livy reports state=dead, Fabric's errorInfo[] often carries the
+    real reason (e.g. ``LIVY_JOB_TIMED_OUT``). Surface it instead of the
+    generic 'failed to connect' message.
+    """
+    mock_headers.return_value = {"Authorization": "Bearer t"}
+    mock_get.return_value = _http_response(
+        200,
+        {
+            "state": "dead",
+            "livyInfo": {"currentState": "dead"},
+            "errorInfo": [
+                {"errorCode": "LIVY_JOB_TIMED_OUT", "message": "Job timed out after 30m"}
+            ],
+        },
+    )
+
+    session = LivySession(_fabric_credentials())
+    session.session_id = "1"
+    with pytest.raises(FailedToConnectError, match="Job timed out after 30m"):
+        session.wait_for_session_start()
+
+
+# ---------------------------------------------------------------------------
+# wait_for_session_start — defensive against missing optional fields
+# ---------------------------------------------------------------------------
+
+
+@patch("dbt.adapters.fabricspark.livysession.requests.get")
+@patch("dbt.adapters.fabricspark.livysession.get_headers")
+def test_wait_for_session_start_tolerates_response_missing_all_state_fields(
+    mock_headers, mock_get
+):
+    """A Fabric SessionResponse with ``state``, ``livyInfo``, and
+    ``fabricSessionStateInfo`` all absent must not raise — these are
+    legitimately optional during the early acquisition window. The poller
+    should simply continue waiting (and time out cleanly if nothing changes).
+    """
+    mock_headers.return_value = {"Authorization": "Bearer t"}
+    mock_get.return_value = _http_response(200, {"id": "1"})
+
+    session = LivySession(_fabric_credentials(session_start_timeout=1))
+    session.session_id = "1"
+    # The poller should hit the configured timeout, not a KeyError or other
+    # unrelated exception.
+    with pytest.raises(FailedToConnectError, match="Timeout"):
+        session.wait_for_session_start()


### PR DESCRIPTION
# Why this change is needed

Per the official Fabric Livy `SessionResponse` swagger contract, every state-related field — `state`, `livyInfo`, `fabricSessionStateInfo`, `id`, `errorInfo` — is **optional**. The adapter currently assumes some of them are always present, which causes user-visible failures in three real situations:

**1. HTTP 430 on Spark capacity overflow.** Fabric returns 430 (non-standard, sibling of 429) when the capacity has too many concurrent Spark sessions. The body is an `ErrorResponse`, not a `SessionResponse`. `response.raise_for_status()` raises an `HTTPError` that the existing `except HTTPError` arm wraps as a generic `Exception("Http Error: ", err_detail)`, hiding the rate-limit nature from the user (and from any retry logic that might want to back off).

**2. Polling during early Fabric acquisition only populates `fabricSessionStateInfo`.** During the window where Fabric is acquiring a Spark session but Livy hasn't minted one yet, the response body contains `fabricSessionStateInfo` only — `state` and `livyInfo` are absent. Today the loop reads `state` and `livyInfo.currentState` only, so capacity-rejection failures (which arrive *only* via `fabricSessionStateInfo.state == "error" / "cancelled"`) cause a silent multi-minute timeout instead of a clear failure.

**3. Polling on HTTP 4xx/5xx parses the body as `SessionResponse`.** The body is actually an `ErrorResponse` (`errorCode` + `message`); the state lookups all return `""`, the loop falls through to the "still starting" branch, and the user waits to a timeout. For terminal codes like 401/403, this is unrecoverable; for transient 4xx/5xx (e.g. 404 during early acquisition, 503 from infra blips), the existing behavior of "keep polling" is actually the right behavior — but only by accident.

Concrete failure modes seen in production:

- `failed to connect: 'state'` — Fabric returned 430, caller did `res["state"]` on an ErrorResponse body.
- 10-minute silent timeout where `fabricSessionStateInfo.state` was `error` from the first poll.
- Generic `failed to connect` despite Fabric's `errorInfo[0].message` being `LIVY_JOB_TIMED_OUT`.

# How

Three minimal, scoped changes in `livysession.py` (no public-API changes; happy path is unchanged):

**`create_session`:**
- Check `response.status_code in (429, 430)` *before* `raise_for_status()` and raise a `FailedToConnectError` naming the rate limit, with a tip about `reuse_session: true`.
- Replace `response.json()["id"]` with `.get("id")` + None check. The `id` field is optional per swagger; missing-id now raises a clear error instead of `KeyError('id')`.

**`wait_for_session_start`:**
- Check `http_res.status_code` *before* parsing as `SessionResponse`:
  - **401, 403, 410** → fail fast (auth/permission/gone — retry cannot help). Surface `errorCode` + `message` from the `ErrorResponse` body.
  - **Other 4xx / all 5xx** → log and continue polling within the configured `session_start_timeout`. This **preserves the transient-blip tolerance** that commit `af831ee` ("HTTP 404 retry-with-backoff for just-submitted statements") established for the statement-poll path; we extend the same philosophy to the session-poll path.
- Read `fabricSessionStateInfo.state` as a third optional state level. Treat `"error"` and `"cancelled"` as terminal — these arrive *before* `livyInfo` exists, so without this check they cause silent timeouts.
- On terminal Livy states (`dead`, `error`, `killed`, `shutting_down` — matching the canonical set accepted in [#65](https://github.com/microsoft/dbt-fabricspark/pull/65)), surface `errorInfo[0].message` instead of the generic "failed to connect".

# Test

New file `tests/unit/test_livysession_optional_fields.py` with 11 tests covering each scenario:

| Scenario | Test |
|---|---|
| HTTP 430 → clear rate-limit error | `test_create_session_clear_error_on_http_430` |
| HTTP 429 → same | `test_create_session_clear_error_on_http_429` |
| 200 with `id` missing → clear "no 'id' field" error | `test_create_session_clear_error_when_response_missing_id` |
| 401 (auth-terminal) → fail fast with errorCode/message | `test_wait_for_session_start_fails_fast_on_auth_terminal_status` |
| Transient 404 → keep polling (succeeds on next poll) | `test_wait_for_session_start_tolerates_transient_4xx` |
| Transient 503 → keep polling | `test_wait_for_session_start_tolerates_transient_5xx` |
| `shutting_down` → terminal | `test_wait_for_session_start_includes_shutting_down_as_terminal` |
| `fabricSessionStateInfo.state == "error"` → clear acquisition-failure | `test_wait_for_session_start_detects_fabric_state_error` |
| `fabricSessionStateInfo.state == "cancelled"` → same | `test_wait_for_session_start_detects_fabric_state_cancelled` |
| `errorInfo[0].message` surfaced when state=dead | `test_wait_for_session_start_surfaces_errorInfo_on_dead` |
| All state fields absent → polls and times out cleanly (no KeyError) | `test_wait_for_session_start_tolerates_response_missing_all_state_fields` |

Local run:

```
tests/unit/test_livysession_optional_fields.py: 11 passed in 1.69s
tests/unit/: 165 passed, 11 skipped
```

(One pre-existing test failure in `tests/unit/test_mlv_api.py::test_raises_on_timeout` — `mock_time.side_effect` exhaustion, unrelated to this change. Happy to fix in a follow-up if useful.)

## Considerations for the reviewer

- **Why these particular 4xx codes are terminal vs transient:** 401/403/410 are user/state errors that retry cannot fix. 404 is treated as transient because Fabric occasionally returns it during the early acquisition window before the session ID is propagated through their infra; the existing legacy code's "keep polling" behavior on 4xx was correct for this case (the loop's `session_start_timeout` bounds the wait).
- **Why a fast-fail on `fabricSessionStateInfo.state`** rather than waiting: that field is populated by Fabric's session-acquisition layer *before* Livy itself is up, so it is the only signal that capacity rejection / cancellation has happened. Without checking it, the loop has nothing else to look at and burns the entire `session_start_timeout`.
- **No retry behavior change for the happy path.** Sessions that go `starting → idle` work exactly as before. The diff only touches the error/edge branches.
