### PR TITLE
feat(auth): add token_command authentication method

### DIFF
--- a/src/dbt/adapters/fabricspark/credentials.py
+++ b/src/dbt/adapters/fabricspark/credentials.py
@@ -73,6 +73,33 @@ class FabricSparkCredentials(Credentials):
     poll_wait: int = 10  # seconds between polls for session start
     poll_statement_wait: float = 0.5  # seconds between polls for statement result
 
+    # token_command auth — invoke an external process to fetch fresh tokens.
+    # Pattern modelled on AWS CLI's `credential_process` and gcloud's
+    # `credential_source`. The command's stdout is parsed as JSON if
+    # possible; otherwise the entire stripped stdout is treated as the
+    # bearer token directly (raw-text mode, e.g. for `gcloud auth
+    # print-access-token` or `az ... --query accessToken -o tsv`).
+    #
+    # Prefer the list-of-args form for cross-platform safety (no shell parsing).
+    # The string form is parsed with shlex on POSIX only.
+    token_command: Optional[Any] = None  # str or list[str]
+    token_command_timeout: int = 30  # seconds before the spawned command is killed
+
+    # JSON path (dot-notation) into the JSON output of `token_command`.
+    # Defaults match the OAuth 2.0 / Microsoft Identity Platform spec.
+    # Common alternatives:
+    #   token_path: "accessToken"          (Azure CLI default JSON output)
+    #   token_path: "data.access_token"    (HashiCorp Vault)
+    # If the output isn't valid JSON, or the path doesn't resolve, the
+    # adapter falls back to using the entire stripped stdout as the token.
+    token_path: str = "access_token"
+    # Path to expiry in the JSON output. Value is auto-interpreted:
+    # numbers > 10^9 are treated as absolute unix timestamps (current
+    # epoch is ~1.76*10^9); smaller values are treated as relative
+    # seconds (RFC 6749 standard). If absent, defaults to a 1-hour
+    # lifetime.
+    expires_path: str = "expires_in"
+
     def __repr__(self) -> str:
         """Mask sensitive fields in repr to prevent credential leakage in logs/tracebacks."""
         return (

--- a/src/dbt/adapters/fabricspark/livysession.py
+++ b/src/dbt/adapters/fabricspark/livysession.py
@@ -5,10 +5,12 @@ import datetime as dt
 import json
 import os
 import re
+import shlex
+import subprocess
 import threading
 import time
 from types import TracebackType
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import requests
 from azure.core.credentials import AccessToken
@@ -185,6 +187,173 @@ def get_default_access_token(credentials: FabricSparkCredentials) -> AccessToken
     return accessToken
 
 
+def _resolve_token_command_args(cmd: Union[str, list]) -> list[str]:
+    """Normalize the ``token_command`` profile field into a subprocess argv list.
+
+    Accepts either a list of strings (preferred — cross-platform safe, no
+    shell parsing) or a single string (parsed via ``shlex.split`` on POSIX,
+    which is **not** safe for Windows shell semantics).
+    """
+    if isinstance(cmd, list):
+        if not cmd:
+            raise DbtRuntimeError("token_command resolved to an empty list")
+        return [str(x) for x in cmd]
+    if isinstance(cmd, str):
+        try:
+            args = shlex.split(cmd, posix=(os.name == "posix"))
+        except ValueError as e:
+            raise DbtRuntimeError(
+                f"token_command string is not a valid shell expression: {e}. "
+                f"Use a list of arguments instead for cross-platform safety."
+            ) from e
+        if not args:
+            raise DbtRuntimeError("token_command resolved to an empty argument list")
+        return args
+    raise DbtRuntimeError(
+        f"token_command must be a string or list of strings, "
+        f"got {type(cmd).__name__}"
+    )
+
+
+def _walk_json_path(data: Any, path: str) -> Any:
+    """Walk a dotted JSON path through nested dicts.
+
+    Returns ``None`` if any segment is missing or a non-dict is hit before
+    the end of the path. ``_walk_json_path({"a": {"b": 1}}, "a.b") == 1``.
+    """
+    cur = data
+    for part in path.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+        if cur is None:
+            return None
+    return cur
+
+
+# Threshold for distinguishing relative-seconds vs absolute-unix-timestamp
+# in the parsed expires field. The current unix epoch is ~1.76 * 10^9;
+# OAuth 2.0 ``expires_in`` values are typically a few thousand at most.
+# Anything past 10^9 is unambiguously a timestamp.
+_EXPIRES_TIMESTAMP_THRESHOLD = 10**9
+
+
+def get_token_command_access_token(credentials: FabricSparkCredentials) -> AccessToken:
+    """Spawn an external command to fetch a fresh Fabric access token.
+
+    Modelled on AWS CLI's ``credential_process`` and gcloud's
+    ``credential_source`` patterns: the adapter runs a user-configured
+    command whenever a fresh token is needed (first connection, and again
+    when the cached token nears expiry — same logic as the other auth
+    methods).
+
+    The command's stdout is read in two modes:
+
+    1. **JSON mode** — if stdout parses as a JSON object and the
+       configured ``token_path`` resolves to a non-empty string. Defaults
+       match OAuth 2.0 / Microsoft Identity Platform shape
+       (``access_token`` + ``expires_in``). Both paths support
+       dot-notation for nested fields, e.g. ``data.access_token`` for
+       HashiCorp Vault or ``accessToken`` for Azure CLI's camelCase
+       output.
+
+    2. **Raw-text mode** — fallback when stdout isn't JSON, or when the
+       JSON token path doesn't resolve. The entire stripped stdout is
+       used as the bearer token. Works for ``gcloud auth
+       print-access-token``, ``az account get-access-token --query
+       accessToken -o tsv``, custom scripts that just ``echo $TOKEN``.
+
+    Expiry interpretation auto-detects: values > 10^9 are treated as
+    absolute unix timestamps; smaller values as relative seconds (RFC
+    6749 standard). When no expiry can be parsed, defaults to a 1-hour
+    lifetime.
+
+    The command is the source of truth for whatever auth flow it
+    implements — HashiCorp Vault, GitHub-Actions OIDC → Entra
+    federation, a corporate SSO proxy, an IDE's local OAuth helper, a
+    smartcard wrapper. The adapter doesn't care.
+
+    Cross-platform: invoked via ``subprocess.run`` with an argv list, no
+    shell. Works identically on Linux/macOS/Windows. The *command* you
+    point at must itself be platform-appropriate (a ``.sh`` won't run
+    natively on Windows; use a Python helper, ``.exe``, or ``.cmd``).
+    """
+    cmd = credentials.token_command
+    if cmd is None:
+        raise DbtRuntimeError(
+            "authentication=token_command requires `token_command` to be set in profiles.yml."
+        )
+
+    args = _resolve_token_command_args(cmd)
+    timeout = credentials.token_command_timeout
+
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as e:
+        raise DbtRuntimeError(
+            f"token_command executable not found: {args[0]!r} ({e})"
+        ) from e
+    except subprocess.TimeoutExpired:
+        raise DbtRuntimeError(
+            f"token_command timed out after {timeout}s: {args}"
+        )
+
+    if result.returncode != 0:
+        raise DbtRuntimeError(
+            f"token_command failed (exit {result.returncode}). "
+            f"stderr: {(result.stderr or '').strip()[:500] or '(empty)'} "
+            f"stdout: {(result.stdout or '').strip()[:200] or '(empty)'}"
+        )
+
+    output = (result.stdout or "").strip()
+    token: Optional[str] = None
+    expires_value: Any = None
+
+    # JSON mode first; raw-text is the fallback.
+    try:
+        data = json.loads(output)
+    except (json.JSONDecodeError, ValueError):
+        data = None
+
+    if isinstance(data, dict):
+        candidate = _walk_json_path(data, credentials.token_path)
+        if isinstance(candidate, str) and candidate:
+            token = candidate
+            expires_value = _walk_json_path(data, credentials.expires_path)
+
+    if token is None:
+        # Raw-text fallback: the entire stdout is the bearer token.
+        if not output:
+            raise DbtRuntimeError(
+                f"token_command produced empty output. args={args}"
+            )
+        token = output
+
+    if expires_value is None:
+        expires_on = int(time.time()) + 3600
+    else:
+        try:
+            expires_int = int(expires_value)
+            if expires_int > _EXPIRES_TIMESTAMP_THRESHOLD:
+                expires_on = expires_int
+            else:
+                expires_on = int(time.time()) + expires_int
+        except (TypeError, ValueError):
+            expires_on = int(time.time()) + 3600
+
+    logger.debug(
+        f"token_command produced token expiring at "
+        f"{dt.datetime.fromtimestamp(expires_on).isoformat()}"
+    )
+    return AccessToken(token=token, expires_on=expires_on)
+
+
 def get_fabric_notebook_access_token(credentials: FabricSparkCredentials) -> AccessToken:
     """
     Get an Azure access token using notebookutils.
@@ -250,6 +419,12 @@ def get_headers(credentials: FabricSparkCredentials, tokenPrint: bool = False) -
             ):
                 logger.info("Using Fabric Notebook auth")
                 accessToken = get_fabric_notebook_access_token(credentials)
+            elif (
+                credentials.authentication
+                and credentials.authentication.lower() == "token_command"
+            ):
+                logger.info("Using token_command auth")
+                accessToken = get_token_command_access_token(credentials)
             else:
                 logger.info("Using SPN auth")
                 accessToken = get_sp_access_token(credentials)

--- a/tests/unit/test_token_command.py
+++ b/tests/unit/test_token_command.py
@@ -1,0 +1,347 @@
+"""Tests for the ``authentication: token_command`` auth method.
+
+Modelled on AWS CLI's ``credential_process`` pattern: dbt spawns a
+user-configured command, reads stdout, and uses the returned token
+until it nears expiry. The adapter parses JSON when possible and falls
+back to raw-text mode otherwise. Token / expiry locations are
+configurable via dot-notation paths.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from azure.core.credentials import AccessToken
+from dbt_common.exceptions import DbtRuntimeError
+
+from dbt.adapters.fabricspark.credentials import FabricSparkCredentials
+from dbt.adapters.fabricspark.livysession import (
+    _resolve_token_command_args,
+    _walk_json_path,
+    get_headers,
+    get_token_command_access_token,
+)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_token_command_args — input normalization
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTokenCommandArgs:
+    def test_list_of_strings_passes_through(self):
+        assert _resolve_token_command_args(["a", "b", "c"]) == ["a", "b", "c"]
+
+    def test_list_with_non_strings_is_coerced(self):
+        # YAML can produce ints in a list (e.g. an arg that's a port number)
+        assert _resolve_token_command_args(["a", 42]) == ["a", "42"]
+
+    def test_empty_list_raises(self):
+        with pytest.raises(DbtRuntimeError, match="empty list"):
+            _resolve_token_command_args([])
+
+    def test_string_is_shell_split(self):
+        assert _resolve_token_command_args("/bin/get-token --user me") == [
+            "/bin/get-token",
+            "--user",
+            "me",
+        ]
+
+    def test_string_preserves_quoted_args(self):
+        assert _resolve_token_command_args('/bin/get-token --user "alice b"') == [
+            "/bin/get-token",
+            "--user",
+            "alice b",
+        ]
+
+    def test_unparseable_string_raises(self):
+        with pytest.raises(DbtRuntimeError, match="not a valid shell expression"):
+            _resolve_token_command_args('"unclosed quote')
+
+    def test_other_types_rejected(self):
+        with pytest.raises(DbtRuntimeError, match="must be a string or list"):
+            _resolve_token_command_args(42)
+
+
+# ---------------------------------------------------------------------------
+# _walk_json_path — dotted-path lookup helper
+# ---------------------------------------------------------------------------
+
+
+class TestWalkJsonPath:
+    def test_top_level(self):
+        assert _walk_json_path({"a": "x"}, "a") == "x"
+
+    def test_nested(self):
+        assert _walk_json_path({"data": {"token": "x"}}, "data.token") == "x"
+
+    def test_deeply_nested(self):
+        assert _walk_json_path({"a": {"b": {"c": 7}}}, "a.b.c") == 7
+
+    def test_missing_returns_none(self):
+        assert _walk_json_path({"a": 1}, "b") is None
+
+    def test_through_non_dict_returns_none(self):
+        assert _walk_json_path({"a": "string"}, "a.b") is None
+
+    def test_camel_case_key(self):
+        # Azure CLI default JSON output uses camelCase
+        assert _walk_json_path({"accessToken": "x"}, "accessToken") == "x"
+
+
+# ---------------------------------------------------------------------------
+# get_token_command_access_token — happy paths (JSON mode)
+# ---------------------------------------------------------------------------
+
+
+def _completed(stdout: str, stderr: str = "", returncode: int = 0) -> MagicMock:
+    """Build a stand-in for a subprocess.CompletedProcess."""
+    proc = MagicMock(spec=subprocess.CompletedProcess)
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.returncode = returncode
+    return proc
+
+
+def _creds(**overrides) -> MagicMock:
+    creds = MagicMock(spec=FabricSparkCredentials)
+    creds.token_command = ["/bin/get-token"]
+    creds.token_command_timeout = 30
+    creds.token_path = "access_token"
+    creds.expires_path = "expires_in"
+    for k, v in overrides.items():
+        setattr(creds, k, v)
+    return creds
+
+
+class TestTokenCommandJsonMode:
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_default_paths_match_oauth2_shape(self, mock_run):
+        """Default token_path/expires_path should resolve a standard OAuth 2.0 response."""
+        mock_run.return_value = _completed(
+            json.dumps({"access_token": "tok-123", "expires_in": 1800})
+        )
+        before = int(time.time())
+
+        token = get_token_command_access_token(_creds())
+
+        assert isinstance(token, AccessToken)
+        assert token.token == "tok-123"
+        assert before + 1800 <= token.expires_on <= int(time.time()) + 1800
+        assert mock_run.call_args.args[0] == ["/bin/get-token"]
+        assert mock_run.call_args.kwargs["capture_output"] is True
+        assert mock_run.call_args.kwargs["text"] is True
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_camelcase_path_resolves_azure_cli_shape(self, mock_run):
+        """Setting token_path='accessToken' resolves Azure CLI's default JSON output."""
+        # az account get-access-token --resource X
+        mock_run.return_value = _completed(
+            json.dumps(
+                {
+                    "accessToken": "az-tok",
+                    "expiresOn": "2099-01-01 00:00:00.000000",
+                    "expires_on": 4070908800,  # absolute unix ts > 10^9
+                    "subscription": "sub",
+                    "tenant": "tenant",
+                    "tokenType": "Bearer",
+                }
+            )
+        )
+        creds = _creds(token_path="accessToken", expires_path="expires_on")
+
+        token = get_token_command_access_token(creds)
+
+        assert token.token == "az-tok"
+        assert token.expires_on == 4070908800
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_dotted_path_resolves_vault_shape(self, mock_run):
+        """Vault returns nested structure; dotted path navigates it."""
+        mock_run.return_value = _completed(
+            json.dumps(
+                {
+                    "data": {
+                        "access_token": "vault-tok",
+                        "lease_duration": 1800,
+                    }
+                }
+            )
+        )
+        creds = _creds(token_path="data.access_token", expires_path="data.lease_duration")
+
+        token = get_token_command_access_token(creds)
+
+        assert token.token == "vault-tok"
+        # 1800 < 10^9 -> relative seconds
+        assert token.expires_on >= int(time.time()) + 1700
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_string_command_is_shell_split(self, mock_run):
+        mock_run.return_value = _completed(
+            json.dumps({"access_token": "x", "expires_in": 60})
+        )
+
+        creds = _creds(token_command="/bin/get-token --user me")
+        get_token_command_access_token(creds)
+
+        assert mock_run.call_args.args[0] == ["/bin/get-token", "--user", "me"]
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_timeout_passed_to_subprocess(self, mock_run):
+        mock_run.return_value = _completed(
+            json.dumps({"access_token": "x", "expires_in": 60})
+        )
+        creds = _creds(token_command_timeout=45)
+
+        get_token_command_access_token(creds)
+        assert mock_run.call_args.kwargs["timeout"] == 45
+
+
+# ---------------------------------------------------------------------------
+# Raw-text mode — fallback when output isn't JSON or path doesn't resolve
+# ---------------------------------------------------------------------------
+
+
+class TestTokenCommandRawTextMode:
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_non_json_stdout_used_as_token(self, mock_run):
+        """gcloud-style: ``print-access-token`` emits the bare token."""
+        mock_run.return_value = _completed("eyJhbGciOiJSUzI1NiIs.payload.sig\n")
+
+        token = get_token_command_access_token(_creds())
+
+        assert token.token == "eyJhbGciOiJSUzI1NiIs.payload.sig"
+        # Default 1h fallback
+        assert token.expires_on >= int(time.time()) + 3500
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_az_tsv_query_form(self, mock_run):
+        """``az ... --query accessToken -o tsv`` emits raw token only."""
+        mock_run.return_value = _completed("ey-az-tsv-token\n")
+        token = get_token_command_access_token(_creds())
+        assert token.token == "ey-az-tsv-token"
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_json_with_unresolved_token_path_falls_back_to_raw(self, mock_run):
+        """If output IS JSON but token_path doesn't resolve, the entire
+        stdout is treated as the bearer token (the JSON literal in this
+        case). The user is responsible for matching the path to the shape.
+        """
+        mock_run.return_value = _completed(
+            json.dumps({"unexpected_key": "hello"})
+        )
+        token = get_token_command_access_token(_creds())
+        # Falls back to raw text — entire stdout
+        assert token.token == json.dumps({"unexpected_key": "hello"})
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_empty_output_raises(self, mock_run):
+        mock_run.return_value = _completed("")
+        with pytest.raises(DbtRuntimeError, match="empty output"):
+            get_token_command_access_token(_creds())
+
+
+# ---------------------------------------------------------------------------
+# Expiry interpretation — auto-detect relative vs absolute
+# ---------------------------------------------------------------------------
+
+
+class TestExpiryInterpretation:
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_small_value_is_relative_seconds(self, mock_run):
+        mock_run.return_value = _completed(
+            json.dumps({"access_token": "x", "expires_in": 60})
+        )
+        token = get_token_command_access_token(_creds())
+        # 60s relative
+        assert int(time.time()) + 50 <= token.expires_on <= int(time.time()) + 60
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_large_value_is_absolute_unix_timestamp(self, mock_run):
+        # value > 10^9 unambiguously means unix timestamp (epoch is ~1.76e9 in 2026)
+        mock_run.return_value = _completed(
+            json.dumps({"access_token": "x", "expires_in": 4070908800})
+        )
+        token = get_token_command_access_token(_creds())
+        assert token.expires_on == 4070908800
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_missing_expiry_defaults_to_one_hour(self, mock_run):
+        mock_run.return_value = _completed(json.dumps({"access_token": "x"}))
+        token = get_token_command_access_token(_creds())
+        assert token.expires_on >= int(time.time()) + 3500
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_malformed_expiry_defaults_to_one_hour(self, mock_run):
+        mock_run.return_value = _completed(
+            json.dumps({"access_token": "x", "expires_in": "not-a-number"})
+        )
+        token = get_token_command_access_token(_creds())
+        assert token.expires_on >= int(time.time()) + 3500
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestTokenCommandErrors:
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_missing_token_command_raises(self, mock_run):
+        creds = _creds(token_command=None)
+        with pytest.raises(DbtRuntimeError, match="requires `token_command`"):
+            get_token_command_access_token(creds)
+        mock_run.assert_not_called()
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_executable_not_found_raises_clear_error(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("no such file")
+        with pytest.raises(DbtRuntimeError, match="executable not found"):
+            get_token_command_access_token(_creds())
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_command_timeout_raises_clear_error(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd=["/bin/get-token"], timeout=30)
+        with pytest.raises(DbtRuntimeError, match="timed out after 30s"):
+            get_token_command_access_token(_creds())
+
+    @patch("dbt.adapters.fabricspark.livysession.subprocess.run")
+    def test_non_zero_exit_includes_stderr(self, mock_run):
+        mock_run.return_value = _completed(
+            stdout="",
+            stderr="vault: invalid token\n",
+            returncode=1,
+        )
+        with pytest.raises(DbtRuntimeError, match="vault: invalid token"):
+            get_token_command_access_token(_creds())
+
+
+# ---------------------------------------------------------------------------
+# get_headers dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestGetHeadersDispatch:
+    def setup_method(self):
+        # Reset module-level token cache
+        import dbt.adapters.fabricspark.livysession as mod
+
+        mod.accessToken = None
+
+    def test_get_headers_dispatches_token_command(self):
+        creds = MagicMock(spec=FabricSparkCredentials)
+        creds.is_local_mode = False
+        creds.authentication = "token_command"
+
+        with patch(
+            "dbt.adapters.fabricspark.livysession.get_token_command_access_token",
+            return_value=AccessToken(token="cmd-tok", expires_on=9999999999),
+        ) as mock_fn:
+            headers = get_headers(creds)
+
+        mock_fn.assert_called_once_with(creds)
+        assert headers["Authorization"] == "Bearer cmd-tok"


### PR DESCRIPTION
# Why this change is needed

Microsoft Fabric access tokens expire after ~1 hour. Today the adapter offers four authentication methods — `CLI`, `SPN`, `fabric_notebook`, and the implicit `accessToken` field — which all rely on credentials the Azure SDK can refresh on its own. There is no supported way to plug a **non-Azure-AD credential source** into the adapter and have it auto-refresh.

That blocks several real, common deployment patterns. Each is a request the Microsoft / dbt-Labs ecosystems are already tracking:

### 1. CI pipelines with federated tokens (Microsoft Entra Workload Identity Federation)

GitHub Actions, Azure DevOps, and Buildkite issue OIDC tokens that get exchanged for short-lived Azure access tokens via [Microsoft Entra Workload Identity Federation](https://learn.microsoft.com/en-us/azure/databricks/dev-tools/auth/provider-github). Builds longer than ~1 hour fail mid-run because the federated token can't be refreshed without re-running the CI step that minted it.

Same failure class as [dbt-labs/dbt-core#14317](https://github.com/dbt-labs/dbt-core/issues/14317) — *"Databricks OAuth (U2M) token expiry causes intermittent build failures after ~10 minutes"* — but for Fabric.

### 2. Long-running dbt jobs under any non-CLI auth (already explicitly tracked in dbt-msft)

[dbt-msft/dbt-sqlserver#156 — "auto-refresh AAD token before the hour expiration"](https://github.com/dbt-msft/dbt-sqlserver/issues/156) tracks this exact pain in the sibling SQL Server adapter. dbt-fabricspark inherits the same constraint: a `dbt build` of a medium project (often >1h) under SPN auth without proactive refresh hits *"authentication has expired"* mid-run. dbt-Labs has [dedicated FAQ pages](https://docs.getdbt.com/faqs/Troubleshooting/auth-expired-error) for this category of error — it's a top-tier user pain.

### 3. Embedded OAuth in third-party apps (no Azure SDK access)

Tools that integrate Fabric on the user's behalf — analytics IDEs, custom AI assistants, data-engineering portals — already manage OAuth flows for their users. The user signs in once to the host app; the app handles refresh. But the dbt adapter can't tap into that flow today: the user has to **re-authenticate via `az login` separately** just to run `dbt`, breaking the seamless experience the host app is designed to provide.

### 4. Enterprise credential brokers (HashiCorp Vault, internal SSO proxies)

Large enterprises run [HashiCorp Vault's Snowflake secrets engine](https://www.hashicorp.com/en/blog/announcing-the-snowflake-secrets-engine), [External Secrets Operator](https://external-secrets.io/latest/provider/hashicorp-vault/), or homegrown SSO proxies that issue short-lived credentials. None of these can plug into dbt-fabricspark today.

The same gap is tracked across the dbt ecosystem: [dbt-fusion#259](https://github.com/dbt-labs/dbt-core/issues/13328), [dbt-bigquery#291](https://github.com/dbt-labs/dbt-bigquery/issues/291). It's a recognised dbt-wide deficiency.

# How

This adds an `authentication: token_command` method, modelled on patterns practitioners already recognise from adjacent ecosystems:

- [AWS CLI's `credential_process`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html)
- [gcloud's `credential_source`](https://cloud.google.com/iam/docs/workload-identity-federation)
- [git's credential helpers](https://git-scm.com/docs/gitcredentials)

The adapter spawns a user-configured command **whenever a fresh token is needed** — first connection, and again whenever the cached token nears expiry (re-using the existing `is_token_refresh_necessary` 5-minute window).

## Output flexibility — handle any broker

Because there's no single canonical token-broker output shape (Azure CLI uses camelCase, OAuth 2.0 uses snake_case, Vault nests under `data`, gcloud emits raw text), the adapter accepts **two output modes** with **path-based extraction**:

**JSON mode** — adapter walks user-configured dotted paths into the JSON output:

```yaml
authentication: token_command
token_command:
  - vault
  - read
  - -format=json
  - fabric/creds/dbt
token_path: data.access_token         # default: "access_token"
expires_path: data.lease_duration     # default: "expires_in"
```

Defaults match OAuth 2.0 / Microsoft Identity Platform spec, so most users won't set these. For non-standard shapes:

| Broker | `token_path` | `expires_path` |
|---|---|---|
| OAuth 2.0 / Microsoft Identity Platform (default) | `access_token` | `expires_in` |
| Azure CLI (`az ... -o json`) | `accessToken` | `expires_on` |
| HashiCorp Vault | `data.access_token` | `data.lease_duration` |
| Custom nested response | `user.creds.token` (any depth) | … |

**Raw-text mode** — fallback when stdout isn't JSON, or when the configured `token_path` doesn't resolve. The entire stripped stdout is used as the bearer token. Works out of the box for:

- `gcloud auth print-access-token`
- `az account get-access-token --resource <r> --query accessToken -o tsv`
- Any custom script that just prints a token

## Expiry interpretation — auto-detected

Some brokers return relative seconds (`expires_in: 3600`), others absolute unix timestamps (`expires_on: 1762346078`). Same `expires_path` field handles both:

- Value > 10⁹ → treated as absolute unix timestamp (current epoch is ~1.76 × 10⁹, so the threshold is unambiguous).
- Value ≤ 10⁹ → treated as relative seconds (RFC 6749 standard).

When no expiry is parseable, defaults to a 1-hour lifetime.

## Cross-platform

Invoked via `subprocess.run` with an argv list — no shell, works identically on Linux/macOS/Windows. The list-form for `token_command` is recommended; a string form is also accepted (parsed with `shlex.split` on POSIX). The *command itself* must be platform-appropriate (a `.sh` won't run natively on Windows; users on Windows can use `.exe`, `.cmd`, or a Python helper).

## Design choices

- **Subprocess, not HTTP.** An HTTP-broker design (adapter calls a configurable URL directly) was considered and rejected. Subprocess is more universal — it can wrap any auth source, including HTTP via `curl`, files, smartcards, IDE-mediated, in-memory CLI state — has a smaller security surface (no URL allowlists or header-secret-redaction concerns), and follows the established AWS/gcloud/git pattern. The same `token_command` slot can wrap an HTTP endpoint via a 3-line shell script.
- **Refresh-by-respawn.** The adapter doesn't try to be smart about refresh schedules. It re-runs `token_command` whenever its cached token is within 5 minutes of expiry — same logic as the existing `is_token_refresh_necessary` path used for SPN / CLI auth. The command is the source of truth.
- **Three new fields** (`token_command`, `token_path`, `expires_path`) plus a 30s subprocess timeout. Defaults make the OAuth 2.0 case zero-config.
- **No new dependencies.** Pure stdlib: `subprocess`, `shlex`, `json`, `time`.
- **No behaviour change** for existing auth methods.

# Test

New file `tests/unit/test_token_command.py` with 31 tests:

| Area | Coverage |
|---|---|
| Argument normalization | list / string / mixed-type / empty / quoted / unparseable / wrong type |
| JSON path walker | top-level / nested / deeply nested / missing / through-non-dict / camelCase |
| JSON mode | default paths match OAuth 2.0; camelCase path matches Azure CLI shape; dotted path matches Vault shape; string command form; subprocess timeout passthrough |
| Raw-text mode | non-JSON stdout used as token; `az ... -o tsv` form; JSON with unresolved token_path falls back to raw text; empty output rejected |
| Expiry interpretation | small value = relative seconds; large value (>10⁹) = absolute unix timestamp; missing = 1h default; malformed = 1h default |
| Error path | missing `token_command` field; `FileNotFoundError`; `subprocess.TimeoutExpired`; non-zero exit (stderr surfaced) |
| `get_headers` integration | `authentication: token_command` dispatches to `get_token_command_access_token` |

All tests are pure-unit (mock `subprocess.run` directly) — no external services required.

```
tests/unit/test_token_command.py: 31 passed in 1.33s
tests/unit/: 151 passed, 11 skipped (excluding 1 pre-existing flake in test_mlv_api.py::test_raises_on_timeout — same flake noted on PR dbt-labs/dbt-core#13235, unrelated)
```

End-to-end verified against a real Fabric workspace using `az account get-access-token --resource https://api.fabric.microsoft.com` as the `token_command`.
