### PR TITLE
fix(relation): flip quote_policy.database

### DIFF
--- a/src/dbt/adapters/fabricspark/relation.py
+++ b/src/dbt/adapters/fabricspark/relation.py
@@ -15,10 +15,28 @@ _VALID_RELATION_TYPES = {t.value for t in RelationType}
 
 @dataclass
 class FabricSparkQuotePolicy(Policy):
-    # database must be quoted (True) so that dbt preserves original casing
-    # through _make_match_kwargs; otherwise mixed-case lakehouse names like
-    # 'DBTTest' get lowered to 'dbttest' and trigger ApproximateMatchError.
-    database: bool = True
+    # ``database`` is unquoted so that dotted database values render as
+    # multiple native identifiers — required for cross-workspace queries.
+    #
+    # When ``database = True``, ``BaseRelation.render()`` wraps the
+    # database value in backticks. A profile setting
+    # ``database: "ws.lh"`` then becomes ``` `ws.lh`.dbo.t ``` — Spark
+    # treats that as a single backtick-quoted identifier with a literal
+    # dot, **not** as the four-part name needed to address ``lh`` in a
+    # different Fabric workspace. With ``database = False``, the same
+    # value renders as ``ws.lh.dbo.t`` (four native unquoted parts) and
+    # the cross-workspace query resolves correctly.
+    #
+    # Single-lakehouse profiles (``database: "lh"``) continue to render
+    # as expected (``lh.dbo.t``) — only the no-longer-quoted style.
+    #
+    # Precondition: workspace, lakehouse, and schema names should be
+    # lowercase. ``_make_match_kwargs`` lowercases unquoted identifiers
+    # internally, so a mixed-case lakehouse (e.g. ``DBTTest``) would
+    # silently mismatch its catalog entry through dbt's relation cache
+    # under unquoted policy. This matches the de-facto convention in
+    # most Fabric environments.
+    database: bool = False
     schema: bool = False
     identifier: bool = False
 

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -348,8 +348,9 @@ class TestSparkAdapter(unittest.TestCase):
             # include_policy.database should be True
             assert rel.include_policy.database is True
             assert rel.include_policy.schema is True
-            # Renders as `database`.schema.identifier (three-part, database quoted)
-            assert str(rel) == "`my_lakehouse`.dbo.my_table"
+            # Renders as database.schema.identifier (three-part, unquoted under
+            # the lowercase-naming convention — quote_policy.database=False)
+            assert str(rel) == "my_lakehouse.dbo.my_table"
         finally:
             FabricSparkRelation._schemas_enabled = False
 
@@ -362,73 +363,36 @@ class TestSparkAdapter(unittest.TestCase):
             rel_three = FabricSparkRelation.create(database="lh", schema="dbo", identifier="t2")
             # Existing relation retains its original policy
             assert str(rel_two) == "lh.t1"
-            # New relation uses updated policy (database quoted)
-            assert str(rel_three) == "`lh`.dbo.t2"
+            # New relation uses updated policy (database unquoted)
+            assert str(rel_three) == "lh.dbo.t2"
         finally:
             FabricSparkRelation._schemas_enabled = False
 
-    def test_mixed_case_database_no_approximate_match_error(self):
-        """Regression test for ApproximateMatchError when lakehouse name uses mixed case.
+    def test_quote_policy_database_is_false(self):
+        """Locks in the contract for cross-workspace queries: quote_policy.database
+        must remain False so that dotted database values render as multiple
+        native identifiers rather than as a single backtick-quoted token.
+        """
+        rel = FabricSparkRelation.create(database="lh", schema="dbo", identifier="t")
+        assert rel.quote_policy.database is False
 
-        When the Fabric lakehouse displayName contains uppercase characters
-        (e.g. 'DBTTest'), the relation cache stores relations with the
-        case-preserved database name from the catalog.  Before the fix,
-        FabricSparkQuotePolicy.database was False, which caused
-        _make_match_kwargs to lowercase the search term ('dbttest'), while
-        the cached relation kept the original casing ('DBTTest').  This
-        mismatch triggered ApproximateMatchError on every rerun.
-
-        The fix sets FabricSparkQuotePolicy.database to True so dbt
-        preserves the original casing through the cache-lookup path.
+    def test_dotted_database_renders_as_four_native_parts(self):
+        """A profile that sets ``database: 'ws.lh'`` — typically used for
+        cross-workspace defer where ``ws`` is the prod workspace name and
+        ``lh`` is the prod lakehouse — must render as four unquoted native
+        identifiers (``ws.lh.schema.table``). With ``quote_policy.database=True``
+        the same value would have been emitted as ``` `ws.lh`.schema.table ```,
+        which Spark resolves as a single identifier with a literal dot —
+        breaking cross-workspace resolution.
         """
         FabricSparkRelation._schemas_enabled = True
         try:
-            # Simulate a cached relation returned by Fabric's catalog with
-            # case-preserved lakehouse name (as list_relations_without_caching
-            # populates it).
-            cached_relation = FabricSparkRelation.create(
-                database="DBTTest",
+            rel = FabricSparkRelation.create(
+                database="my_workspace.my_lakehouse",
                 schema="dbo",
-                identifier="my_first_model",
-                type=FabricSparkRelation.get_relation_type.Table,
+                identifier="my_table",
             )
-
-            # Verify that the quote policy defaults database to True
-            assert cached_relation.quote_policy.database is True
-
-            # The search term that dbt passes through _make_match_kwargs.
-            # With quoting.database=True, the database name is NOT lowercased,
-            # so it stays as "DBTTest" and matches exactly.
-            assert cached_relation.matches(
-                database="DBTTest", schema="dbo", identifier="my_first_model"
-            )
-
-            # Also verify that mixed-case database renders correctly
-            # with backtick quoting (harmless in Spark SQL).
-            assert str(cached_relation) == "`DBTTest`.dbo.my_first_model"
-        finally:
-            FabricSparkRelation._schemas_enabled = False
-
-    def test_mixed_case_database_lowered_raises_approximate_match(self):
-        """Verify that searching with a lowered database name vs. mixed-case
-        cached relation correctly raises ApproximateMatchError, confirming
-        the root cause described in the issue."""
-        from dbt_common.exceptions import CompilationError
-
-        FabricSparkRelation._schemas_enabled = True
-        try:
-            cached_relation = FabricSparkRelation.create(
-                database="DBTTest",
-                schema="dbo",
-                identifier="my_first_model",
-                type=FabricSparkRelation.get_relation_type.Table,
-            )
-            # Searching with the lowered form should raise ApproximateMatchError
-            # (which is a CompilationError subclass) since 'dbttest' != 'DBTTest'.
-            with self.assertRaises(CompilationError):
-                cached_relation.matches(
-                    database="dbttest", schema="dbo", identifier="my_first_model"
-                )
+            assert str(rel) == "my_workspace.my_lakehouse.dbo.my_table"
         finally:
             FabricSparkRelation._schemas_enabled = False
 


### PR DESCRIPTION
Closed — incorrect approach. The proper fix is to extend the relation model with optional 4-part naming (workspace.database.schema.identifier) as an additive feature, leaving `quote_policy.database = True` and existing 3-part rendering untouched. Will be re-submitted as a separate PR with a different design.