### PR TITLE
fix(livy): support fetchmany — unblocks dbt show --inline-direct (fixes #163)

### DIFF
--- a/src/dbt/adapters/fabricspark/livysession.py
+++ b/src/dbt/adapters/fabricspark/livysession.py
@@ -1369,6 +1369,28 @@ class LivySessionConnectionWrapper(object):
     def fetchall(self):
         return self._cursor.fetchall()
 
+    def fetchmany(self, size=None):
+        """Return up to ``size`` rows from the executed query result.
+
+        DB-API 2.0 / PEP 249 cursor method. ``dbt-adapters``'
+        ``get_result_from_cursor`` calls this with the configured fetch
+        limit (e.g. ``dbt show --inline-direct`` always invokes
+        ``cursor.fetchmany(limit)``); without this method the show /
+        inline-direct flow crashes with ``AttributeError``.
+
+        Implementation: delegate to ``fetchall`` (the underlying Livy
+        cursor materialises the entire result set anyway — there is no
+        true streaming chunk in the Livy statement-result protocol) and
+        slice. ``size=None`` returns all rows, matching the PEP 249
+        contract for cursors with ``arraysize`` unset.
+        """
+        rows = self._cursor.fetchall()
+        if rows is None:
+            return []
+        if size is not None:
+            return rows[:size]
+        return rows
+
     def execute(self, sql, bindings=None):
         if sql.strip().endswith(";"):
             sql = sql.strip()[:-1]

--- a/tests/unit/test_livysession.py
+++ b/tests/unit/test_livysession.py
@@ -506,3 +506,45 @@ class TestFixBinding:
             "(cast(1.0 as bigint),cast('Cote d\\'Ivoire' as string)),"
             "(cast(2.0 as bigint),cast('Tonga' as string))"
         )
+
+
+class TestFetchmany:
+    """Tests for LivySessionConnectionWrapper.fetchmany — DB-API 2.0 cursor method.
+
+    ``dbt-adapters``' ``get_result_from_cursor`` always calls
+    ``cursor.fetchmany(limit)``; without this method ``dbt show
+    --inline-direct`` (and any other inline-fetch flow) crashes with
+    ``AttributeError``.
+    """
+
+    def _wrapper_with_rows(self, rows):
+        """Build a wrapper whose underlying cursor returns ``rows`` from fetchall."""
+        wrapper = LivySessionConnectionWrapper(handle=MagicMock())
+        wrapper._cursor = MagicMock()
+        wrapper._cursor.fetchall.return_value = rows
+        return wrapper
+
+    def test_returns_first_n_rows_when_size_smaller_than_total(self):
+        wrapper = self._wrapper_with_rows([1, 2, 3, 4, 5])
+        assert wrapper.fetchmany(3) == [1, 2, 3]
+
+    def test_returns_all_rows_when_size_larger_than_total(self):
+        wrapper = self._wrapper_with_rows([1, 2])
+        assert wrapper.fetchmany(10) == [1, 2]
+
+    def test_size_none_returns_all_rows(self):
+        """PEP 249 contract: ``size=None`` returns all rows."""
+        wrapper = self._wrapper_with_rows([1, 2, 3])
+        assert wrapper.fetchmany() == [1, 2, 3]
+
+    def test_size_zero_returns_empty(self):
+        wrapper = self._wrapper_with_rows([1, 2, 3])
+        assert wrapper.fetchmany(0) == []
+
+    def test_none_rows_returns_empty(self):
+        """Defensive: if the underlying cursor reports ``fetchall() is None``
+        (e.g. statement returned no result set), surface an empty list rather
+        than crashing on the slice."""
+        wrapper = self._wrapper_with_rows(None)
+        assert wrapper.fetchmany(5) == []
+        assert wrapper.fetchmany() == []


### PR DESCRIPTION
# Why this change is needed

`LivySessionConnectionWrapper` is missing the DB-API 2.0 / [PEP 249](https://peps.python.org/pep-0249/#fetchmany) `fetchmany` method that the dbt-adapters base layer depends on. `dbt show --inline-direct "<sql>"` (and any other code path going through `get_result_from_cursor`) crashes with:

```
File ".../dbt/adapters/sql/connections.py", line 202, in get_result_from_cursor
    rows = cursor.fetchmany(limit)
           ^^^^^^^^^^^^^^^^
AttributeError: 'LivySessionConnectionWrapper' object has no attribute 'fetchmany'.
Did you mean: 'fetchall'?
```

Fixes #163.

# How

Add a `fetchmany(size=None)` method on `LivySessionConnectionWrapper`:

```python
def fetchmany(self, size=None):
    rows = self._cursor.fetchall()
    if rows is None:
        return []
    if size is not None:
        return rows[:size]
    return rows
```

## Why this implementation, not a streaming one

Fabric's Livy statement-result API returns the **entire result set in one JSON response** — there is no server-side cursor or paging primitive in the protocol. By the time a client calls `fetchmany`, the rows have already been materialised in driver memory. There is nothing meaningful to "stream" client-side: slicing a local list is faithful to the actual underlying behaviour.

This is intentionally **not pretending to be a streaming cursor**. The cursor contract is satisfied (PEP 249), but the implementation makes no claims of incremental row delivery that the protocol can't back.

## User responsibility note (will also surface in docs)

Because the full result set is materialised in driver memory before `fetchmany` slices, users running `dbt show --inline-direct` against very large tables can blow the driver. The same holds for any direct-cursor consumer.

Two safe patterns:
- Wrap the query with an explicit `LIMIT N` in the SQL itself when using `--inline-direct`.
- Or use `dbt show --inline` (without `-direct`), which auto-wraps the query with the configured limit at the SQL layer — Spark only computes / returns N rows server-side.

This PR doesn't change either of those flows; it just stops `--inline-direct` from raising `AttributeError`.

# Test

5 new tests in `tests/unit/test_livysession.py::TestFetchmany`:

| Case | Expected |
|---|---|
| `size < total` | first N rows |
| `size > total` | all rows |
| `size=None` (no arg) | all rows (PEP 249 default) |
| `size=0` | empty list |
| underlying `fetchall() is None` | empty list (defensive) |

All pure-unit (mock the underlying cursor at `_cursor.fetchall`).

Local run:

```
tests/unit/test_livysession.py::TestFetchmany ............ 5 passed
tests/unit/                                  160 passed, 11 skipped
```

No public-API surface changes beyond adding the missing method. No new dependencies. No other code paths affected.
