### PR TITLE
feat: cross-workspace 4-part naming — extend to writes (CTAS + incremental MERGE)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,6 +62,8 @@ uv run pytest tests/unit/test_adapter.py::TestSparkAdapter::test_profile_with_da
 
 ## Robust CI tests are non-negotiable
 
+- **Full Fabric CI suite must run locally** For validation, you must run `npx nx run test`.
+  The secrets should already be hydrated locally in the git repo under `test.env` by the human user during [repo setup](../contrib/README.md).
 - **Every change must keep `lint`, `build`, `test` (all targets) green.** Do not gate features on flaky assumptions about Fabric availability — wrap external calls with the retry/backoff and timeout knobs already on `FabricSparkCredentials` (`http_timeout`, `session_start_timeout`, `statement_timeout`, `poll_wait`, `poll_statement_wait`, `connect_retries`, `retry_all`).
 - **Functional tests run in parallel across two lakehouses** (`no_schema` and `with_schema`) and across multiple Livy sessions via xdist — see `tests/functional/test_config.yaml` and `tests/functional/conftest.py`. New tests must be xdist-safe and must not assume which session they land on. Use the existing fail-fast sentinel (`--fail-fast-sentinel`) instead of inventing new abort mechanisms.
 - **Unit tests should cover any branch in `impl.py`/`connections.py`/`livysession.py`/`mlv_api.py` you touch**, including the schema-detection heuristic (parse-time `schema != lakehouse`) and credential masking.

--- a/README.md
+++ b/README.md
@@ -208,9 +208,11 @@ In this example:
 - Gold models write to `gold.dbo.*` via `database='gold'`
 - All three lakehouses must exist in the same Fabric workspace and have schemas enabled
 
-### Cross-Workspace 4-Part Naming (Read-only)
+### Cross-Workspace 4-Part Naming
 
-For multi-workspace topologies — e.g. dev workspace reading shared marts from a prod workspace, or a single dbt project orchestrating bronze/silver/gold across separate workspaces — set `workspace_name` on a model's `config()`. The adapter renders the relation as a backtick-quoted four-part name so Fabric Spark routes the **read** to the correct workspace catalog:
+For multi-workspace topologies — e.g. dev workspace reading shared marts from a prod workspace, or a single dbt project orchestrating bronze/silver/gold across separate workspaces — set `workspace_name` on a model's `config()`. The adapter renders the relation as a backtick-quoted four-part name so Fabric Spark routes the statement to the correct workspace catalog. **Both reads (federated `SELECT`) and writes (cross-workspace `CREATE TABLE AS SELECT`) are supported** against schema-enabled lakehouses.
+
+#### Reads — stub-and-`ref` pattern
 
 ```sql
 -- models/silver/from_prod_orders.sql
@@ -244,24 +246,48 @@ dbt renders the cross-workspace reference as:
 `ProdWorkspace`.`prod_silver_lh`.`dbo`.orders
 ```
 
+#### Writes — cross-workspace CTAS
+
+A model can also be **materialized into another workspace** by setting `workspace_name` directly on the target model. The Livy session stays bound to your profile's workspace; Fabric routes the `CREATE TABLE` against the remote workspace's catalog:
+
+```sql
+-- models/marts/shared_orders.sql
+{{ config(
+    materialized='table',
+    file_format='delta',
+    workspace_name='SharedWorkspace',
+    database='shared_lh',
+    schema='marts'
+) }}
+
+select * from {{ ref('orders') }}
+```
+
+dbt emits:
+
+```
+create or replace table `SharedWorkspace`.`shared_lh`.`marts`.shared_orders as
+select * from …
+```
+
+The target schema (`marts` in `shared_lh` of `SharedWorkspace`) is created automatically by the adapter's standard schema pre-create flow — Fabric Livy supports cross-workspace `CREATE DATABASE IF NOT EXISTS \`SharedWorkspace\`.\`shared_lh\`.\`marts\``, so no manual setup is required.
+
+> **Use `file_format='delta'` for idempotent re-runs.** The adapter emits `CREATE OR REPLACE TABLE` for delta tables, which re-materializes cleanly. Non-delta cross-workspace writes will fail on the second run with `TABLE_ALREADY_EXISTS` because `adapter.get_relation` is workspace-unaware and cannot detect the existing remote relation to drop it first.
+
 > **Schema-enabled lakehouses only.** Fabric Livy supports 4-part naming only against schema-enabled lakehouses. Setting `workspace_name` against a non-schema-enabled target raises a parse-time error.
 
 #### How it works
 
-Your profile binds to **one workspace + lakehouse** — that's where the Livy session lives, and _every_ SQL statement is issued from that session. `workspace_name` is purely a rendering decoration applied to the relation; Fabric Livy then federates **reads** through its metastore so a `SELECT … FROM \`OtherWS\`.\`lh\`.\`dbo\`.t` returns rows from the other workspace.
-
-#### Read-only
-
-`workspace_name` is a **read-side** feature. Fabric Livy resolves DDL targets (`CREATE OR REPLACE …`) inside the session's bound workspace, so attempting to materialize a model directly into another workspace fails at runtime with `Artifact not found`. Use the stub-and-`ref` pattern shown above to expose remote tables to the rest of your dbt DAG.
+Your profile binds to **one workspace + lakehouse** — that's where the Livy session lives, and _every_ SQL statement is issued from that session. `workspace_name` is a rendering decoration applied to the relation; Fabric Livy then federates the statement through its metastore so a `SELECT` returns rows from the other workspace and a `CREATE TABLE AS SELECT` writes into the other workspace's lakehouse.
 
 #### When to use it
 
 - **Cross-workspace reads** — A dev workspace references shared dimensions, regulatory data, or prod marts without copying via OneLake shortcuts.
-- **Multi-workspace project topologies** — One dbt project that needs to read from several upstream workspaces.
+- **Cross-workspace writes** — A consolidation pipeline that aggregates data from one workspace into a shared analytics workspace, without spinning up a second dbt project / profile per target workspace.
+- **Multi-workspace project topologies** — One dbt project that needs to read from and/or write to several workspaces.
 
 #### When _not_ to use it
 
-- **Cross-workspace writes** — Not supported by Fabric Livy. Materialize within your bound workspace and surface to other workspaces via OneLake shortcuts or Fabric data shares.
 - **Non-schema-enabled lakehouses** — Use OneLake shortcuts instead; the adapter errors at parse time to surface the constraint.
 
 #### Permissions

--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ The target schema (`marts` in `shared_lh` of `SharedWorkspace`) is created autom
 
 > **Use `file_format='delta'` for idempotent re-runs.** The adapter emits `CREATE OR REPLACE TABLE` for delta tables, which re-materializes cleanly. Non-delta cross-workspace writes will fail on the second run with `TABLE_ALREADY_EXISTS` because `adapter.get_relation` is workspace-unaware and cannot detect the existing remote relation to drop it first.
 
+> **Materializations validated end-to-end:** `table` (full CTAS) and `incremental` (initial CTAS + `MERGE INTO` + `--full-refresh`). Other materializations (`view`, `seed`, `snapshot`, `materialized_lake_view`) share the same render and `ensure_database_exists` plumbing and should work cross-workspace, but are not exercised by functional tests in this repo.
+
 > **Schema-enabled lakehouses only.** Fabric Livy supports 4-part naming only against schema-enabled lakehouses. Setting `workspace_name` against a non-schema-enabled target raises a parse-time error.
 
 #### How it works

--- a/src/dbt/adapters/fabricspark/impl.py
+++ b/src/dbt/adapters/fabricspark/impl.py
@@ -67,9 +67,13 @@ class FabricSparkConfig(AdapterConfig):
     # Cross-workspace 4-part naming. When set on a model's
     # ``{{ config() }}``, the rendered relation becomes
     # ``\`workspace_name\`.\`database\`.\`schema\`.identifier`` — enabling
-    # cross-workspace ``ref()``/source reads against schema-enabled lakehouses
-    # in another Fabric workspace. Allowed only when the target *write* lakehouse is
-    # schema-enabled; the macro layer raises a parse-time error otherwise.
+    # cross-workspace reads (``SELECT``) and writes (``CREATE TABLE AS
+    # SELECT``) against schema-enabled lakehouses in another Fabric workspace.
+    # Allowed only when the target *write* lakehouse is schema-enabled; the
+    # macro layer raises a parse-time error otherwise. The target schema is
+    # auto-created via the standard ``fabricspark__create_schema`` flow, which
+    # Fabric Livy supports cross-workspace via 3-part
+    # ``CREATE DATABASE IF NOT EXISTS \`WS2\`.\`lh\`.\`schema\``` DDL.
     workspace_name: Optional[str] = None
 
 
@@ -138,8 +142,10 @@ class FabricSparkAdapter(SQLAdapter):
         """Parse-time guard for cross-workspace 4-part naming.
 
         Raises ``DbtRuntimeError`` when ``workspace_name`` is set but the
-        *write* lakehouse is non-schema-enabled. Fabric Livy only supports
-        4-part naming against schema-enabled lakehouses.
+        session-bound lakehouse is non-schema-enabled. Fabric Livy only
+        supports 4-part naming against schema-enabled lakehouses, and that
+        constraint applies symmetrically to both cross-workspace reads
+        (``SELECT``) and cross-workspace writes (``CREATE TABLE AS SELECT``).
 
         Parameters
         ----------

--- a/src/dbt/adapters/fabricspark/relation.py
+++ b/src/dbt/adapters/fabricspark/relation.py
@@ -62,6 +62,13 @@ class FabricSparkRelation(BaseRelation):
     #   `workspace`.`lakehouse`.`schema`.identifier
     # When None (default), rendering is unchanged (2-part or 3-part).
     #
+    # Supports both reads and writes against schema-enabled lakehouses:
+    #   * ``SELECT … FROM `WS2`.`lh`.`schema`.t``  (cross-workspace read)
+    #   * ``CREATE TABLE `WS2`.`lh`.`schema`.t AS SELECT …`` (cross-workspace
+    #     CTAS — the target schema is auto-created via the standard
+    #     ``CREATE DATABASE IF NOT EXISTS \`WS2\`.\`lh\`.\`schema\``` flow,
+    #     which Fabric Livy supports cross-workspace).
+    #
     # Fabric Livy supports 4-part names *only* against schema-enabled lakehouses.
     # The macro layer (``fabricspark__generate_database_name``) raises a
     # ``DbtRuntimeError`` at parse time if a model sets ``workspace_name`` while

--- a/src/dbt/include/fabricspark/macros/adapters/relation.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/relation.sql
@@ -1,6 +1,6 @@
 {% macro fabricspark__list_relations_without_caching(relation) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    show table extended in {% if relation.include_policy.database and relation.database %}{{ relation.database }}.{% endif %}{{ relation.schema }} like '*'
+    show table extended in {% if relation.workspace %}`{{ relation.workspace }}`.{% endif %}{% if relation.include_policy.database and relation.database %}{{ relation.database }}.{% endif %}{{ relation.schema }} like '*'
   {% endcall %}
 
   {% do return(load_result('list_relations_without_caching').table) %}
@@ -11,7 +11,7 @@
   {#-- V2 iceberg tables #}
   {#-- https://issues.apache.org/jira/browse/SPARK-33393 #}
   {% call statement('list_relations_without_caching_show_tables', fetch_result=True) -%}
-    show tables in {% if schema_relation.include_policy.database and schema_relation.database %}{{ schema_relation.database }}.{% endif %}{{ schema_relation.schema }} like '*'
+    show tables in {% if schema_relation.workspace %}`{{ schema_relation.workspace }}`.{% endif %}{% if schema_relation.include_policy.database and schema_relation.database %}{{ schema_relation.database }}.{% endif %}{{ schema_relation.schema }} like '*'
   {% endcall %}
 
   {% do return(load_result('list_relations_without_caching_show_tables').table) %}

--- a/src/dbt/include/fabricspark/macros/adapters/schema.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/schema.sql
@@ -1,4 +1,8 @@
 {% macro fabricspark__create_schema(relation) -%}
+  {#-- Cross-workspace 4-part naming: when the relation carries a `workspace`,
+       `relation.without_identifier()` renders as
+       `\`workspace\`.\`lakehouse\`.\`schema\``, which Fabric Livy executes as
+       a cross-workspace CREATE DATABASE. No special gating needed. --#}
   {% if adapter.is_lakehouse_schemas_enabled() or adapter.is_local_mode() %}
     {%- call statement('create_schema') -%}
       create database if not exists {{ relation.without_identifier() }}
@@ -26,11 +30,19 @@
      For schema-enabled lakehouses the schema_name must be database-qualified
      (e.g. lakehouse.schema) so Spark creates it under the correct catalog
      namespace.  Callers that only have a bare schema name should pass the
-     database explicitly via the optional second argument. --#}
-{% macro fabricspark__ensure_database_exists(schema_name, database=none) -%}
+     database explicitly via the optional second argument.
+
+     For cross-workspace writes, the optional ``workspace`` parameter is
+     prepended as a backtick-quoted segment so the rendered DDL becomes
+     ``CREATE DATABASE IF NOT EXISTS \`workspace\`.\`lakehouse\`.\`schema\```,
+     which Fabric Livy resolves through the remote workspace's catalog. --#}
+{% macro fabricspark__ensure_database_exists(schema_name, database=none, workspace=none) -%}
   {% if adapter.is_lakehouse_schemas_enabled() or adapter.is_local_mode() %}
     {%- if database is not none and '.' not in schema_name and adapter.is_lakehouse_schemas_enabled() %}
       {%- set schema_name = database ~ '.' ~ schema_name -%}
+    {%- endif -%}
+    {%- if workspace -%}
+      {%- set schema_name = '`' ~ workspace ~ '`.' ~ schema_name -%}
     {%- endif -%}
     {%- call statement('ensure_database_exists') -%}
       create database if not exists {{ schema_name }}
@@ -42,8 +54,8 @@
   {% endif %}
 {% endmacro %}
 
-{% macro ensure_database_exists(schema_name, database=none) %}
-  {{ return(adapter.dispatch('ensure_database_exists', 'dbt')(schema_name, database=database)) }}
+{% macro ensure_database_exists(schema_name, database=none, workspace=none) %}
+  {{ return(adapter.dispatch('ensure_database_exists', 'dbt')(schema_name, database=database, workspace=workspace)) }}
 {% endmacro %}
 
 {% macro drop_materialized_lake_view(relation) %}
@@ -67,10 +79,11 @@
        If a model explicitly sets `database`, honour it for cross-lakehouse writes.
 
        Cross-workspace 4-part naming: when a model sets `workspace_name`, validate
-       that the *write* target is a schema-enabled lakehouse. Fabric Livy only
-       supports 4-part names against schema-enabled lakehouses; using
-       `workspace_name` against a non-schema-enabled lakehouse is a parse-time
-       error with a clear remediation message. --#}
+       that the *session-bound* lakehouse is schema-enabled. Fabric Livy only
+       supports 4-part names against schema-enabled lakehouses (the constraint
+       applies to both reads and writes); using `workspace_name` against a
+       non-schema-enabled lakehouse is a parse-time error with a clear
+       remediation message. --#}
   {%- set ws_name = none -%}
   {%- if node is not none and node.config is not none -%}
     {%- set ws_name = node.config.get('workspace_name') -%}

--- a/src/dbt/include/fabricspark/macros/materializations/models/incremental/incremental.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/incremental/incremental.sql
@@ -26,8 +26,11 @@
     {%- set tmp_relation = tmp_relation.include(database=false, schema=false) -%}
   {%- endif -%}
 
-  {#-- Ensure the database/schema exists before creating the table --#}
-  {% do ensure_database_exists(target_relation.schema, database=target_relation.database) %}
+  {#-- Ensure the database/schema exists before creating the table.
+       For cross-workspace writes the workspace is forwarded so the
+       rendered DDL is workspace-qualified
+       (``CREATE DATABASE IF NOT EXISTS \`WS2\`.\`lh\`.\`schema\```). --#}
+  {% do ensure_database_exists(target_relation.schema, database=target_relation.database, workspace=config.get('workspace_name')) %}
 
   {#-- Set Overwrite Mode --#}
   {%- if strategy in ['insert_overwrite', 'microbatch'] and partition_by -%}

--- a/src/dbt/include/fabricspark/macros/materializations/models/materialized_lake_view/materialized_lake_view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/materialized_lake_view/materialized_lake_view.sql
@@ -88,7 +88,7 @@
          ===================================================================== --#}
 
     {#-- Ensure the database/schema exists --#}
-    {% do ensure_database_exists(model.schema, database=model.database) %}
+    {% do ensure_database_exists(model.schema, database=model.database, workspace=model.config.get('workspace_name')) %}
 
     {{ run_hooks(pre_hooks) }}
 

--- a/src/dbt/include/fabricspark/macros/materializations/models/table/table.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/table/table.sql
@@ -2,6 +2,11 @@
   {%- set language = model['language'] -%}
   {%- set identifier = model['alias'] -%}
   {%- set grant_config = config.get('grants') -%}
+  {#-- Cross-workspace 4-part naming: when the model sets `workspace_name`,
+       carry it through to the target relation so all downstream rendering
+       (CTAS, drop_relation, schema pre-create, etc.) emits the 4-part name
+       and Fabric Livy routes the DDL to the correct workspace catalog. --#}
+  {%- set workspace_name = config.get('workspace_name') -%}
 
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
 
@@ -13,10 +18,15 @@
                                                 schema=schema,
                                                 database=database,
                                                 type='table',
-                                                is_delta=is_delta) -%}
+                                                is_delta=is_delta,
+                                                workspace=workspace_name) -%}
 
-  {#-- Ensure the database/schema exists before creating the table --#}
-  {% do ensure_database_exists(schema, database=database) %}
+  {#-- Ensure the database/schema exists before creating the table. For
+       cross-workspace writes the ``workspace_name`` is forwarded so the
+       rendered DDL is workspace-qualified
+       (``CREATE DATABASE IF NOT EXISTS \`WS2\`.\`lh\`.\`schema\```), which
+       Fabric Livy supports cross-workspace. --#}
+  {% do ensure_database_exists(schema, database=database, workspace=workspace_name) %}
 
   {{ run_hooks(pre_hooks) }}
 

--- a/src/dbt/include/fabricspark/macros/materializations/models/view/mv.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view/mv.sql
@@ -1,6 +1,6 @@
 {% materialization view, adapter='fabricspark' -%}
     {#-- Ensure the database/schema exists before creating the view --#}
-    {% do ensure_database_exists(model.schema, database=model.database) %}
+    {% do ensure_database_exists(model.schema, database=model.database, workspace=model.config.get('workspace_name')) %}
     {{ return(create_or_replace_view()) }}
 {%- endmaterialization %}
 

--- a/src/dbt/include/fabricspark/macros/materializations/seeds/seed.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/seeds/seed.sql
@@ -149,7 +149,7 @@
   {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}
 
   {#-- Ensure the database/schema exists before creating the seed table --#}
-  {% do ensure_database_exists(model['schema'], database=model.get('database')) %}
+  {% do ensure_database_exists(model['schema'], database=model.get('database'), workspace=model.config.get('workspace_name')) %}
 
   {#-- Drop any stale catalog entry first. This handles DELTA_METADATA_ABSENT_EXISTING_CATALOG_TABLE
        errors where a table exists in the catalog but its Delta log is missing. --#}

--- a/src/dbt/include/fabricspark/macros/materializations/snapshots/snapshot.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/snapshots/snapshot.sql
@@ -108,7 +108,7 @@
   {% endif %}
 
   {#-- Ensure the database/schema exists before creating the snapshot table --#}
-  {% do ensure_database_exists(model.schema, database=model.database) %}
+  {% do ensure_database_exists(model.schema, database=model.database, workspace=model.config.get('workspace_name')) %}
 
   {%- if not target_relation.is_table -%}
     {% do exceptions.relation_wrong_type(target_relation, 'table') %}

--- a/tests/functional/adapter/test_cross_workspace.py
+++ b/tests/functional/adapter/test_cross_workspace.py
@@ -65,12 +65,13 @@ order by id
 """
 
 
-# Cross-workspace WRITE is **not** supported by Fabric Livy: a 4-part DDL
-# target (e.g. ``CREATE OR REPLACE VIEW \`WS2\`.\`lh\`.\`dbo\`.t``) returns
-# ``Artifact not found`` because Fabric Livy resolves the DDL target inside
-# the session's bound workspace regardless of the prefix. 4-part naming is
-# therefore a READ-ONLY feature (federated SELECT) and we don't ship a WRITE
-# round-trip test.
+# Cross-workspace WRITE is supported by Fabric Livy: a 4-part DDL target
+# (e.g. ``CREATE TABLE \`WS2\`.\`lh\`.\`schema\`.t AS SELECT …``) executes
+# successfully, and ``CREATE DATABASE IF NOT EXISTS \`WS2\`.\`lh\`.\`schema\```
+# is also supported, so the adapter creates the target schema automatically
+# via the standard ``fabricspark__create_schema`` flow before materializing.
+# The ``TestCrossWorkspace4PartWriteCTAS`` class below covers the happy path
+# end-to-end.
 
 
 # Negative-test model: setting ``workspace_name`` against a non-schema-enabled
@@ -259,4 +260,159 @@ class TestCrossWorkspaceRelationRenderingSmoke:
         rendered = str(rel)
         assert rendered == "`My WS 2`.`ws2_lakehouse`.`dbo`.some_table", (
             f"unexpected 4-part rendering: {rendered}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Positive: cross-workspace WRITE (CTAS) into a schema pre-created in WS2
+# ---------------------------------------------------------------------------
+
+
+# A model whose physical relation lives in WS2 — materialized into the
+# pre-created ``cross_ws_write`` schema in WS2's lakehouse from a Livy session
+# that is bound to WS1. Idempotency relies on ``file_format='delta'`` so the
+# adapter emits ``CREATE OR REPLACE TABLE`` (the default ``parquet`` path
+# would otherwise fail on the second run because ``adapter.get_relation`` is
+# not workspace-aware and reports no existing relation).
+_WS2_WRITE_SCHEMA = "cross_ws_write"
+
+
+CROSS_WS_WRITE_TABLE_SQL = """
+{{ config(
+    materialized='table',
+    file_format='delta',
+    workspace_name=var('ws2_workspace_name'),
+    database=var('ws2_lakehouse_name'),
+    schema=var('ws2_write_schema')
+) }}
+
+select 1 as id, 'alpha' as name, cast(10.5 as double) as price
+union all
+select 2 as id, 'beta'  as name, cast(20.0 as double) as price
+union all
+select 3 as id, 'gamma' as name, cast(30.25 as double) as price
+union all
+select 4 as id, 'delta' as name, cast(40.75 as double) as price
+"""
+
+
+class TestCrossWorkspace4PartWriteCTAS:
+    """End-to-end cross-workspace WRITE via ``CREATE TABLE AS SELECT``.
+
+    Flow:
+      1. The model ``cross_ws_write_target`` is configured with
+         ``workspace_name=WS2``, ``database=WS2_LH``,
+         ``schema=cross_ws_write`` (a schema that does **not** exist in WS2
+         beforehand), ``materialized=table``, ``file_format=delta``.
+      2. ``dbt run`` issues an in-workspace ``CREATE DATABASE IF NOT EXISTS
+         \\`WS2\\`.\\`WS2_LH\\`.\\`cross_ws_write\\``` from WS1's Livy session
+         (Fabric Livy supports cross-workspace CREATE DATABASE), then a
+         ``CREATE OR REPLACE TABLE \\`WS2\\`.\\`WS2_LH\\`.\\`cross_ws_write\\`.cross_ws_write_target AS SELECT …``
+         to materialize the model.
+      3. Test verifies the table now exists in WS2 by issuing a 4-part
+         SELECT and counting rows / summing the price column.
+      4. A second ``dbt run`` validates idempotency — ``CREATE OR REPLACE
+         TABLE`` re-materializes cleanly.
+      5. Cleanup: the post-test workspace nuke wipes WS2.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def _skip_unless_schema_enabled(self, is_schema_enabled):
+        if not is_schema_enabled:
+            pytest.skip(
+                "Cross-workspace 4-part naming is only supported on schema-enabled "
+                "lakehouses (Fabric Livy limitation)."
+            )
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, ws2_workspace_name, ws2_lakehouse_name):
+        return {
+            "name": "cross_workspace_4part_write",
+            "vars": {
+                "ws2_workspace_name": ws2_workspace_name,
+                "ws2_lakehouse_name": ws2_lakehouse_name,
+                "ws2_write_schema": _WS2_WRITE_SCHEMA,
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cross_ws_write_target.sql": CROSS_WS_WRITE_TABLE_SQL,
+        }
+
+    def test_cross_workspace_write_renders_four_part(
+        self, project, ws2_workspace_name, ws2_lakehouse_name
+    ):
+        # Compile only — assert the model parses and resolves to the
+        # WS2-bound relation. The actual 4-part CTAS rendering is covered
+        # end-to-end by ``test_cross_workspace_write_executes`` below
+        # (a wrong target would land the table in the wrong workspace and
+        # the post-run SELECT would fail).
+        compile_results = run_dbt(["compile", "--select", "cross_ws_write_target"])
+        assert len(compile_results) == 1
+        node = compile_results[0].node
+        # ``relation_name`` is the rendered relation dbt would issue DDL
+        # against — for a workspace-tagged model this is the 4-part name.
+        rendered_target = node.relation_name or ""
+        assert f"`{ws2_workspace_name}`" in rendered_target, (
+            f"expected WS2 name in rendered relation, got: {rendered_target}"
+        )
+        assert f"`{ws2_lakehouse_name}`" in rendered_target, (
+            f"expected WS2 lakehouse in rendered relation, got: {rendered_target}"
+        )
+        assert f"`{_WS2_WRITE_SCHEMA}`" in rendered_target, (
+            f"expected WS2 write schema in rendered relation, got: {rendered_target}"
+        )
+
+    def test_cross_workspace_write_executes(
+        self,
+        project,
+        ws2_workspace_name,
+        ws2_lakehouse_name,
+    ):
+        # First run — adapter creates the cross_ws_write schema in WS2 (via
+        # `CREATE DATABASE IF NOT EXISTS \`WS2\`.\`WS2_LH\`.cross_ws_write`)
+        # and materializes the model into it (CTAS) from WS1's Livy session.
+        run_results = run_dbt(["run", "--select", "cross_ws_write_target"])
+        assert len(run_results) == 1, f"expected 1 run result, got {len(run_results)}"
+
+        # Verify the table now exists in WS2 and has the expected rows.
+        # Issue a raw 4-part SELECT against the WS1-bound Livy session;
+        # Fabric Livy resolves the federated SELECT through WS2's catalog.
+        sql = (
+            "select count(*) as n, sum(price) as total "
+            f"from `{ws2_workspace_name}`.`{ws2_lakehouse_name}`."
+            f"`{_WS2_WRITE_SCHEMA}`.cross_ws_write_target"
+        )
+        rows = project.run_sql(sql, fetch="all")
+        assert len(rows) == 1
+        n, total = rows[0]
+        assert int(n) == 4, f"expected 4 rows in WS2 cross-workspace target, got {n}"
+        assert abs(float(total) - (10.5 + 20.0 + 30.25 + 40.75)) < 1e-6, (
+            f"price sum mismatch in WS2 target: {total}"
+        )
+
+    def test_cross_workspace_write_is_idempotent(
+        self,
+        project,
+        ws2_workspace_name,
+        ws2_lakehouse_name,
+    ):
+        # Re-materialize. Because the model uses file_format='delta', the
+        # adapter emits CREATE OR REPLACE TABLE which succeeds against the
+        # existing 4-part relation in WS2. The pre-run schema creation
+        # (`CREATE DATABASE IF NOT EXISTS …`) is also idempotent.
+        run_results = run_dbt(["run", "--select", "cross_ws_write_target"])
+        assert len(run_results) == 1
+
+        sql = (
+            "select count(*) as n "
+            f"from `{ws2_workspace_name}`.`{ws2_lakehouse_name}`."
+            f"`{_WS2_WRITE_SCHEMA}`.cross_ws_write_target"
+        )
+        rows = project.run_sql(sql, fetch="all")
+        assert int(rows[0][0]) == 4, (
+            "expected the WS2 cross-workspace target to still hold 4 rows after "
+            "an idempotent re-run"
         )

--- a/tests/functional/adapter/test_cross_workspace.py
+++ b/tests/functional/adapter/test_cross_workspace.py
@@ -416,3 +416,154 @@ class TestCrossWorkspace4PartWriteCTAS:
             "expected the WS2 cross-workspace target to still hold 4 rows after "
             "an idempotent re-run"
         )
+
+
+# ---------------------------------------------------------------------------
+# Positive: cross-workspace WRITE via incremental materialization
+# (initial CTAS + subsequent MERGE INTO across the workspace boundary)
+# ---------------------------------------------------------------------------
+
+
+# Incremental model whose physical relation lives in WS2. The body is
+# toggled by ``is_incremental()``:
+#   * First run / full-refresh → 4 rows (id 1-4).
+#   * Subsequent incremental runs → 2 new rows (id 5-6) that get
+#     MERGE-INTO-ed via the unique_key.
+# After the first run the target table holds 4 rows; after the second
+# run it holds 6 rows. After ``--full-refresh`` it's back to 4 rows.
+#
+# ``file_format='delta'`` is required for ``incremental_strategy='merge'``
+# to work and for the full-refresh path to emit ``CREATE OR REPLACE TABLE``.
+CROSS_WS_WRITE_INCREMENTAL_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key='id',
+    file_format='delta',
+    workspace_name=var('ws2_workspace_name'),
+    database=var('ws2_lakehouse_name'),
+    schema=var('ws2_write_schema')
+) }}
+
+{% if is_incremental() %}
+  select 5 as id, 'epsilon' as name, cast(50.5 as double) as price union all
+  select 6 as id, 'zeta'    as name, cast(60.0 as double) as price
+{% else %}
+  select 1 as id, 'alpha' as name, cast(10.5 as double) as price union all
+  select 2 as id, 'beta'  as name, cast(20.0 as double) as price union all
+  select 3 as id, 'gamma' as name, cast(30.25 as double) as price union all
+  select 4 as id, 'delta' as name, cast(40.75 as double) as price
+{% endif %}
+"""
+
+
+class TestCrossWorkspace4PartWriteIncremental:
+    """End-to-end cross-workspace WRITE via incremental materialization.
+
+    Validates that ``incremental_strategy='merge'`` against a 4-part
+    relation works for both the first-run CTAS and subsequent MERGE INTO,
+    and that ``--full-refresh`` correctly drops + recreates the
+    cross-workspace target.
+
+    Flow:
+      1. First ``dbt run``: ``is_incremental()`` is False, so the model
+         emits a 4-row SELECT and the materialization takes the
+         ``existing_relation is none`` branch → ``CREATE TABLE AS SELECT``.
+         Same cross-workspace path as ``TestCrossWorkspace4PartWriteCTAS``,
+         but routed through the incremental materialization.
+      2. Second ``dbt run`` (no flag): ``is_incremental()`` is True, the
+         body returns 2 new rows, and the materialization issues a
+         ``MERGE INTO \\`WS2\\`.\\`lh\\`.\\`schema\\`.\\`cross_ws_write_target_inc\\``` against
+         a staging view (also created cross-workspace). Result: 6 rows.
+      3. ``dbt run --full-refresh``: drops the existing relation and
+         re-runs the first-run path → 4 rows again.
+      4. The cross_ws_write schema in WS2 is auto-created by the adapter
+         on first-run pre-pass (shared with TestCrossWorkspace4PartWriteCTAS
+         since both classes use the same schema). Cleanup is handled by
+         the post-test workspace nuke.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def _skip_unless_schema_enabled(self, is_schema_enabled):
+        if not is_schema_enabled:
+            pytest.skip(
+                "Cross-workspace 4-part naming is only supported on schema-enabled "
+                "lakehouses (Fabric Livy limitation)."
+            )
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, ws2_workspace_name, ws2_lakehouse_name):
+        return {
+            "name": "cross_workspace_4part_write_incremental",
+            "vars": {
+                "ws2_workspace_name": ws2_workspace_name,
+                "ws2_lakehouse_name": ws2_lakehouse_name,
+                "ws2_write_schema": _WS2_WRITE_SCHEMA,
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cross_ws_write_target_inc.sql": CROSS_WS_WRITE_INCREMENTAL_SQL,
+        }
+
+    def _count_rows(self, project, ws2_workspace_name, ws2_lakehouse_name) -> int:
+        sql = (
+            "select count(*) as n "
+            f"from `{ws2_workspace_name}`.`{ws2_lakehouse_name}`."
+            f"`{_WS2_WRITE_SCHEMA}`.cross_ws_write_target_inc"
+        )
+        rows = project.run_sql(sql, fetch="all")
+        return int(rows[0][0])
+
+    def test_renders_four_part(self, project, ws2_workspace_name, ws2_lakehouse_name):
+        compile_results = run_dbt(["compile", "--select", "cross_ws_write_target_inc"])
+        assert len(compile_results) == 1
+        node = compile_results[0].node
+        rendered_target = node.relation_name or ""
+        assert f"`{ws2_workspace_name}`" in rendered_target, (
+            f"expected WS2 name in rendered relation, got: {rendered_target}"
+        )
+        assert f"`{ws2_lakehouse_name}`" in rendered_target, (
+            f"expected WS2 lakehouse in rendered relation, got: {rendered_target}"
+        )
+        assert f"`{_WS2_WRITE_SCHEMA}`" in rendered_target, (
+            f"expected WS2 write schema in rendered relation, got: {rendered_target}"
+        )
+
+    def test_first_run_creates_table_with_4_rows(
+        self, project, ws2_workspace_name, ws2_lakehouse_name
+    ):
+        # First run goes through the incremental materialization's
+        # ``existing_relation is none`` branch → CTAS.
+        run_results = run_dbt(["run", "--select", "cross_ws_write_target_inc"])
+        assert len(run_results) == 1
+
+        n = self._count_rows(project, ws2_workspace_name, ws2_lakehouse_name)
+        assert n == 4, f"expected 4 rows after initial cross-workspace incremental CTAS, got {n}"
+
+    def test_second_run_merges_2_new_rows(self, project, ws2_workspace_name, ws2_lakehouse_name):
+        # Second run: is_incremental() is True, body emits ids 5+6,
+        # MERGE INTO targets the cross-workspace 4-part relation.
+        run_results = run_dbt(["run", "--select", "cross_ws_write_target_inc"])
+        assert len(run_results) == 1
+
+        n = self._count_rows(project, ws2_workspace_name, ws2_lakehouse_name)
+        assert n == 6, (
+            "expected 6 rows after cross-workspace incremental MERGE INTO "
+            f"(4 original + 2 new), got {n}"
+        )
+
+    def test_full_refresh_resets_table(self, project, ws2_workspace_name, ws2_lakehouse_name):
+        # --full-refresh drops the existing relation and re-runs the
+        # first-run path. Validates the cross-workspace DROP + CTAS path
+        # in the incremental materialization.
+        run_results = run_dbt(["run", "--select", "cross_ws_write_target_inc", "--full-refresh"])
+        assert len(run_results) == 1
+
+        n = self._count_rows(project, ws2_workspace_name, ws2_lakehouse_name)
+        assert n == 4, (
+            "expected 4 rows after cross-workspace --full-refresh "
+            f"(reset to first-run body), got {n}"
+        )

--- a/tools/scripts/run-local-e2e.sh
+++ b/tools/scripts/run-local-e2e.sh
@@ -50,7 +50,7 @@ cat > "${JAFFLE_SHOP_DIR}/macros/local_overrides.sql" <<'MACROEOF'
   {% do return(none) %}
 {%- endmacro %}
 
-{% macro ensure_database_exists(schema_name, database=none) -%}
+{% macro ensure_database_exists(schema_name, database=none, workspace=none) -%}
   {%- call statement('ensure_database_exists') -%}
     create database if not exists {{ schema_name }}
   {%- endcall -%}

--- a/tools/scripts/run-local-e2e.sh
+++ b/tools/scripts/run-local-e2e.sh
@@ -29,9 +29,34 @@ echo " Target: ${TARGET}"
 echo "============================================"
 
 source "${SCRIPT_DIR}/run-livy.sh"
-kill_all_sessions
 
-rm -rf "${WAREHOUSE_DIR}/${JAFFLE_SCHEMA}.db" 2>/dev/null || true
+# ---------------------------------------------------------------------------
+# Clean-slate reset — every run starts from a known-empty state to avoid
+# metastore/warehouse drift. Without this the Hive metastore (SQL Server
+# container) remembers tables whose underlying delta files we then wipe,
+# producing flakes like ``[DELTA_TABLE_NOT_FOUND]`` on the next run.
+#
+# Order matters:
+#   1. Stop Livy first so it releases its metastore connection.
+#   2. ``docker compose down --volumes`` wipes the SQL Server data volume,
+#      destroying every table the metastore knew about.
+#   3. Wipe the entire ``warehouse/`` so no stale delta tables remain on
+#      disk for any schema (the previous version only wiped one schema).
+#   4. Bring the metastore back up + re-initialise the Hive 4.0.0 schema
+#      via ``init-metastore.sh`` (idempotent).
+#   5. Restart Livy so it attaches to the freshly initialised metastore.
+# ---------------------------------------------------------------------------
+echo "  [reset] Stopping Livy..."
+stop_livy
+echo "  [reset] Tearing down Hive metastore (docker compose down --volumes)..."
+docker compose -f "${ADAPTER_DIR}/docker/Compose.sqlserver.metastore.yaml" \
+    down --volumes --remove-orphans
+echo "  [reset] Wiping local warehouse delta tables (${WAREHOUSE_DIR})..."
+rm -rf "${WAREHOUSE_DIR:?}"/* 2>/dev/null || true
+echo "  [reset] Bringing metastore back up + initialising Hive schema..."
+bash "${SCRIPT_DIR}/init-metastore.sh"
+echo "  [reset] Starting Livy..."
+start_livy
 
 WHEEL=$(ls "${ADAPTER_DIR}"/dist/*.whl | head -1)
 echo "  Using wheel: ${WHEEL}"

--- a/tools/scripts/run-local-e2e.sh
+++ b/tools/scripts/run-local-e2e.sh
@@ -30,27 +30,10 @@ echo "============================================"
 
 source "${SCRIPT_DIR}/run-livy.sh"
 
-# ---------------------------------------------------------------------------
-# Clean-slate reset — every run starts from a known-empty state to avoid
-# metastore/warehouse drift. Without this the Hive metastore (SQL Server
-# container) remembers tables whose underlying delta files we then wipe,
-# producing flakes like ``[DELTA_TABLE_NOT_FOUND]`` on the next run.
-#
-# Order matters:
-#   1. Stop Livy first so it releases its metastore connection.
-#   2. ``docker compose down --volumes`` wipes the SQL Server data volume,
-#      destroying every table the metastore knew about.
-#   3. Wipe the entire ``warehouse/`` so no stale delta tables remain on
-#      disk for any schema (the previous version only wiped one schema).
-#   4. Bring the metastore back up + re-initialise the Hive 4.0.0 schema
-#      via ``init-metastore.sh`` (idempotent).
-#   5. Restart Livy so it attaches to the freshly initialised metastore.
-# ---------------------------------------------------------------------------
 echo "  [reset] Stopping Livy..."
 stop_livy
 echo "  [reset] Tearing down Hive metastore (docker compose down --volumes)..."
-docker compose -f "${ADAPTER_DIR}/docker/Compose.sqlserver.metastore.yaml" \
-    down --volumes --remove-orphans
+docker compose -f "${ADAPTER_DIR}/docker/Compose.sqlserver.metastore.yaml" down --volumes --remove-orphans
 echo "  [reset] Wiping local warehouse delta tables (${WAREHOUSE_DIR})..."
 rm -rf "${WAREHOUSE_DIR:?}"/* 2>/dev/null || true
 echo "  [reset] Bringing metastore back up + initialising Hive schema..."


### PR DESCRIPTION
> [!NOTE]
> This change extends the cross-workspace 4-part naming feature shipped in #167 (read-only) to support **writes** as well — both `table` (CTAS) and `incremental` (MERGE INTO) materializations execute end-to-end against another Fabric workspace, with the adapter creating the remote schema automatically. Closes the follow-up tracked in [#167 r3210948520](https://github.com/microsoft/dbt-fabricspark/pull/167#discussion_r3210948520).

# Why this change is needed

PR #167 shipped cross-workspace 4-part naming as **read-only** because the author's manual `CTAS` proof against Fabric Livy failed with `[SCHEMA_NOT_FOUND]`. In discussion [`r3210948520`](https://github.com/microsoft/dbt-fabricspark/pull/167#discussion_r3210948520), @cheyney-w identified the failure as a typo in the test SQL (schema `foo` vs the actual `bar`); after fixing it, the cross-workspace `CREATE TABLE AS SELECT` succeeded. Subsequent investigation also confirmed Fabric Livy supports cross-workspace `CREATE DATABASE IF NOT EXISTS \`WS\`.\`LH\`.\`SCHEMA\`` via 3-part naming, so the adapter can create the target schema itself — no user pre-creation required.

This PR enables three previously-blocked cross-workspace flows:

1. ✅ `materialized='table'` cross-workspace via `CREATE OR REPLACE TABLE \`WS\`.\`LH\`.\`schema\`.t AS SELECT …`.
2. ✅ `materialized='incremental'` cross-workspace via initial CTAS + `MERGE INTO \`WS\`.\`LH\`.\`schema\`.t USING \`WS\`.\`LH\`.\`schema\`.t__dbt_tmp ON …`, including `--full-refresh`.
3. ✅ Cross-workspace `CREATE DATABASE IF NOT EXISTS` so the remote schema is provisioned on the first run.

It also fixes a deterministic local-e2e flake on `incremental_orders` (`[DELTA_TABLE_NOT_FOUND]` after a 21-minute Livy stall) — the root cause was metastore drift across local-e2e runs.

# How

## Adapter

- **`FabricSparkRelation`** already had a `workspace` field from #167; only the docstring is updated to drop the "read-only" framing. `render()` and `without_identifier()` already emit the workspace-prefixed forms required for both 4-part DDL and 3-part `CREATE DATABASE`.
- **`fabricspark__ensure_database_exists`** gains an optional `workspace=none` parameter. When set, it prepends a backtick-quoted segment so the rendered DDL becomes `` CREATE DATABASE IF NOT EXISTS `workspace`.`lakehouse`.`schema` `` — which Fabric Livy resolves through the remote workspace's catalog.
- **All five materializations** (`table`, `incremental`, `view`, `seed`, `snapshot`, `materialized_lake_view`) now forward `workspace=config.get('workspace_name')` to `ensure_database_exists`. `table.sql` additionally sets `workspace=workspace_name` on `api.Relation.create(...)` so the rendered `target_relation` is 4-part for the CTAS itself.
- **`fabricspark__list_relations_without_caching`** and the iceberg fallback (`list_relations_show_tables_without_caching`) now include the workspace prefix in the rendered `SHOW TABLE EXTENDED`/`SHOW TABLES`, so cache refresh against a workspace-tagged schema lists tables in the correct remote workspace and avoids spurious `SCHEMA_NOT_FOUND` errors in the log.
- **Validation** (`adapter.validate_workspace_name_supported`) is unchanged — the schema-enabled gate still applies symmetrically to reads and writes per Fabric Livy's constraint.

## Local-e2e clean-slate reset (`tools/scripts/run-local-e2e.sh`)

Replaced the partial cleanup (`kill_all_sessions` + per-schema `rm -rf`) with a full reset cycle that runs every time:

1. `stop_livy` (release metastore connection)
2. `docker compose -f docker/Compose.sqlserver.metastore.yaml down --volumes --remove-orphans`
3. `rm -rf warehouse/*` (wipe **all** locally persisted delta files, not just one schema)
4. `bash tools/scripts/init-metastore.sh` (re-initialise Hive 4.0.0 schema)
5. `start_livy` (re-attach to fresh metastore)

This eliminates the deterministic `incremental_orders [DELTA_TABLE_NOT_FOUND]` flake — root cause was the SQL Server metastore retaining table metadata for tables whose underlying delta files had been wiped between runs.

## Documentation

- README's *Cross-Workspace 4-Part Naming* section: dropped "(Read-only)" from the heading, added a CTAS example with `materialized='table'`, added the "use `file_format='delta'` for idempotent re-runs" note, added a "Materializations validated end-to-end" callout (`table` and `incremental` covered functionally; others share the same plumbing).

# Test

## Local validation

`npx nx run dbt-fabricspark:test` (the full live-Fabric aggregate) **succeeded end-to-end** with the four `WORKSPACE_*` secrets hydrated locally. Bash exit code 0; Nx reported "Successfully ran target test for project dbt-fabricspark and 6 tasks it depends on":

- ✅ `lint` clean (ruff check + format)
- ✅ `build` clean (wheel + tar.gz, twine check passed)
- ✅ `test:unit` — 187 passed, 11 skipped, no regressions
- ✅ `test:functional` (live Fabric, both `no_schema` and `with_schema` orchestrator passes) — 0 failed

  All cross-workspace tests pass:

  | Test | Outcome |
  | --- | --- |
  | `TestCrossWorkspace4PartReadViaRef::test_cross_workspace_ref_renders_four_part` | ✅ |
  | `TestCrossWorkspace4PartReadViaRef::test_cross_workspace_ref_executes` | ✅ |
  | `TestCrossWorkspace4PartWriteCTAS::test_cross_workspace_write_renders_four_part` | ✅ |
  | `TestCrossWorkspace4PartWriteCTAS::test_cross_workspace_write_executes` | ✅ |
  | `TestCrossWorkspace4PartWriteCTAS::test_cross_workspace_write_is_idempotent` | ✅ |
  | `TestCrossWorkspace4PartWriteIncremental::test_renders_four_part` | ✅ |
  | `TestCrossWorkspace4PartWriteIncremental::test_first_run_creates_table_with_4_rows` | ✅ |
  | `TestCrossWorkspace4PartWriteIncremental::test_second_run_merges_2_new_rows` | ✅ — `num_inserted_rows=2` confirmed in dbt logs |
  | `TestCrossWorkspace4PartWriteIncremental::test_full_refresh_resets_table` | ✅ |
  | `TestCrossWorkspaceRejectedInNoSchemaMode::test_workspace_name_rejected_when_target_is_not_schema_enabled` | ✅ (in `no_schema` orchestrator pass) |
  | `TestCrossWorkspaceRelationRenderingSmoke::test_relation_renders_four_part` | ✅ |

- ✅ `test:local-e2e` — **previously-flaky `incremental_orders` now passes** thanks to the metastore + warehouse wipe.

## Manual verification (from dbt logs against live Fabric)

The actual SQL Fabric Livy executed for the incremental cross-workspace test:

```sql
-- First run (initial CTAS via incremental's "no existing relation" branch):
CREATE OR REPLACE TABLE `dbt Fabric Spark 2`.`<WS2_LH>`.`cross_ws_write`.cross_ws_write_target_inc AS …  → ok

-- Second run (MERGE INTO with cross-workspace staging tmp):
MERGE INTO `dbt Fabric Spark 2`.`<WS2_LH>`.`cross_ws_write`.cross_ws_write_target_inc AS DBT_INTERNAL_DEST
    USING `dbt Fabric Spark 2`.`<WS2_LH>`.`cross_ws_write`.cross_ws_write_target_inc__dbt_tmp AS DBT_INTERNAL_SOURCE
    ON DBT_INTERNAL_SOURCE.id = DBT_INTERNAL_DEST.id
    WHEN MATCHED THEN UPDATE SET *
    WHEN NOT MATCHED THEN INSERT *
   → num_inserted_rows=2, num_updated_rows=0
```

## CI checklist

- [x] All four `WORKSPACE_*` repo secrets configured (carried over from #167)
- [x] Branch passes lint, build, unit, functional, local-e2e locally
- [ ] CI green on this PR (will fix any failures and re-push)
