### PR TITLE
feat: add token_credential auth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- Added `token_credential` authentication method — load a user-supplied `azure.core.credentials.TokenCredential` implementation via dotted path (`credential_class` + `credential_kwargs`). Lets callers plug in tokens minted by their own OAuth flow, Workload Identity Federation, Vault, etc. without going through `az login` or SPN config (#166). **Security note:** `credential_kwargs` values are passed verbatim to the credential class and may contain secrets — prefer `{{ env_var(...) }}` over inline values and ensure `profiles.yml` has restricted file permissions. The dotted path is INFO-logged on each connect for forensic visibility.
+
 ## v1.10.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### New Features
-
-- Added `token_credential` authentication method — load a user-supplied `azure.core.credentials.TokenCredential` implementation via dotted path (`credential_class` + `credential_kwargs`). Lets callers plug in tokens minted by their own OAuth flow, Workload Identity Federation, Vault, etc. without going through `az login` or SPN config (#166). **Security note:** `credential_kwargs` values are passed verbatim to the credential class and may contain secrets — prefer `{{ env_var(...) }}` over inline values and ensure `profiles.yml` has restricted file permissions. The dotted path is INFO-logged on each connect for forensic visibility.
-
 ## v1.10.1
 
 ### Bug Fixes

--- a/src/dbt/adapters/fabricspark/credentials.py
+++ b/src/dbt/adapters/fabricspark/credentials.py
@@ -48,8 +48,8 @@ class FabricSparkCredentials(Credentials):
     client_secret: Optional[str] = None
     tenant_id: Optional[str] = None
     authentication: str = "CLI"
-    # token_credential auth: dotted path to a TokenCredential implementation
-    # loaded via importlib at connect time. See discussion #166.
+    # Dotted path to a TokenCredential implementation loaded via importlib
+    # when authentication='token_credential'.
     credential_class: Optional[str] = None
     credential_kwargs: Dict[str, Any] = field(default_factory=dict)
     connect_retries: int = 1

--- a/src/dbt/adapters/fabricspark/credentials.py
+++ b/src/dbt/adapters/fabricspark/credentials.py
@@ -48,6 +48,10 @@ class FabricSparkCredentials(Credentials):
     client_secret: Optional[str] = None
     tenant_id: Optional[str] = None
     authentication: str = "CLI"
+    # token_credential auth: dotted path to a TokenCredential implementation
+    # loaded via importlib at connect time. See discussion #166.
+    credential_class: Optional[str] = None
+    credential_kwargs: Dict[str, Any] = field(default_factory=dict)
     connect_retries: int = 1
     connect_timeout: int = 10
     create_shortcuts: Optional[bool] = False
@@ -83,6 +87,8 @@ class FabricSparkCredentials(Credentials):
             f"authentication={self.authentication!r}, "
             f"client_id={self.client_id!r}, "
             f"client_secret='***', "
+            f"credential_class={self.credential_class!r}, "
+            f"credential_kwargs_keys={sorted(map(str, self.credential_kwargs.keys()))!r}, "
             f"accessToken='***')"
         )
 
@@ -159,6 +165,24 @@ class FabricSparkCredentials(Credentials):
         for key in required_keys:
             if key not in self.spark_config:
                 raise ValueError(f"Missing required key: {key}")
+
+        # token_credential auth requires a dotted-path credential_class.
+        # Conversely, credential_class/credential_kwargs are only valid with
+        # authentication=token_credential — fail fast on mis-wired profiles.
+        is_token_credential_auth = (
+            isinstance(self.authentication, str)
+            and self.authentication.lower() == "token_credential"
+        )
+        if is_token_credential_auth and not self.credential_class:
+            raise DbtRuntimeError(
+                "authentication='token_credential' requires `credential_class` "
+                "(dotted path to an azure.core.credentials.TokenCredential)."
+            )
+        if not is_token_credential_auth and (self.credential_class or self.credential_kwargs):
+            raise DbtRuntimeError(
+                "`credential_class` and `credential_kwargs` are only valid when "
+                "authentication='token_credential'."
+            )
 
     def apply_lakehouse_properties(self, lakehouse_properties: dict) -> None:
         """Apply lakehouse properties after fetching them from the Fabric REST API.

--- a/src/dbt/adapters/fabricspark/livysession.py
+++ b/src/dbt/adapters/fabricspark/livysession.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import atexit
 import datetime as dt
+import importlib
 import json
 import os
 import re
@@ -11,7 +12,7 @@ from types import TracebackType
 from typing import Any, Optional
 
 import requests
-from azure.core.credentials import AccessToken
+from azure.core.credentials import AccessToken, TokenCredential
 from azure.identity import AzureCliCredential, ClientSecretCredential
 from dbt_common.exceptions import DbtDatabaseError, DbtRuntimeError
 from dbt_common.utils.encoding import DECIMALS
@@ -42,6 +43,18 @@ _token_lock = threading.Lock()
 # Process-level cache for lakehouse properties (avoids repeated API calls per connection open)
 _lakehouse_props_cache: dict[tuple[str, str, str], dict] = {}
 _lakehouse_props_lock = threading.Lock()
+
+# Process-level cache for user-supplied TokenCredential instances, keyed by
+# the (dotted_path, repr-of-sorted-kwargs) tuple. Lets refresh-on-expiry
+# reuse the same instance without re-importing on every header build. Using
+# repr() of the sorted kwargs makes the key stable even when kwargs contain
+# unhashable values (nested dicts, lists from YAML).
+_custom_credential_cache: dict[tuple[str, str], Any] = {}
+_custom_credential_lock = threading.Lock()
+
+# Dotted-path identifier validation (defence-in-depth — importlib won't
+# execute shell, but rejecting non-identifier chars gives clearer errors).
+_DOTTED_PATH_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)+$")
 
 
 def read_session_id_from_file(file_path: str) -> Optional[str]:
@@ -185,6 +198,81 @@ def get_default_access_token(credentials: FabricSparkCredentials) -> AccessToken
     return accessToken
 
 
+def _load_custom_credential(credentials: FabricSparkCredentials) -> Any:
+    """Import and instantiate the user-supplied TokenCredential.
+
+    The instance is cached per (dotted_path, kwargs) tuple so that refresh
+    cycles reuse the same object (matching how azure-identity credentials
+    are typically held).
+    """
+    dotted = credentials.credential_class
+    if not dotted:
+        raise DbtRuntimeError("authentication='token_credential' requires `credential_class`.")
+    if not _DOTTED_PATH_PATTERN.match(dotted):
+        raise DbtRuntimeError(
+            f"credential_class must be a dotted path like 'pkg.module.ClassName', got: {dotted!r}"
+        )
+    kwargs = credentials.credential_kwargs or {}
+    # repr() of sorted items keeps the cache key hashable even when kwargs
+    # contain nested dicts/lists from YAML.
+    cache_key = (dotted, repr(sorted(kwargs.items(), key=lambda kv: kv[0])))
+
+    with _custom_credential_lock:
+        if cache_key in _custom_credential_cache:
+            return _custom_credential_cache[cache_key]
+
+        module_path, _, class_name = dotted.rpartition(".")
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError as exc:
+            raise DbtRuntimeError(
+                f"Could not import module for credential_class={dotted!r}: {exc}"
+            ) from exc
+        try:
+            cls = getattr(module, class_name)
+        except AttributeError as exc:
+            raise DbtRuntimeError(
+                f"Module {module_path!r} has no attribute {class_name!r} "
+                f"(from credential_class={dotted!r})"
+            ) from exc
+
+        try:
+            instance = cls(**kwargs)
+        except TypeError as exc:
+            raise DbtRuntimeError(
+                f"Failed to instantiate {dotted!r} with credential_kwargs: {exc}"
+            ) from exc
+
+        # TokenCredential is a @runtime_checkable Protocol — isinstance does
+        # the structural get_token check, so any class exposing get_token
+        # passes whether or not it inherits from TokenCredential.
+        if not isinstance(instance, TokenCredential):
+            raise DbtRuntimeError(
+                f"{dotted!r} must implement azure.core.credentials.TokenCredential "
+                f"(missing callable get_token)."
+            )
+
+        _custom_credential_cache[cache_key] = instance
+        return instance
+
+
+def get_token_credential_access_token(credentials: FabricSparkCredentials) -> AccessToken:
+    """Get an access token from a user-supplied TokenCredential class.
+
+    Loaded by dotted path from ``credentials.credential_class`` and
+    instantiated with ``credentials.credential_kwargs``. See discussion
+    https://github.com/microsoft/dbt-fabricspark/discussions/166.
+    """
+    credential = _load_custom_credential(credentials)
+    result = credential.get_token(AZURE_CREDENTIAL_SCOPE)
+    if not isinstance(result, AccessToken):
+        raise DbtRuntimeError(
+            f"{credentials.credential_class!r}.get_token() must return an "
+            f"azure.core.credentials.AccessToken, got {type(result).__name__}."
+        )
+    return result
+
+
 def get_fabric_notebook_access_token(credentials: FabricSparkCredentials) -> AccessToken:
     """
     Get an Azure access token using notebookutils.
@@ -250,6 +338,12 @@ def get_headers(credentials: FabricSparkCredentials, tokenPrint: bool = False) -
             ):
                 logger.info("Using Fabric Notebook auth")
                 accessToken = get_fabric_notebook_access_token(credentials)
+            elif (
+                credentials.authentication
+                and credentials.authentication.lower() == "token_credential"
+            ):
+                logger.info(f"Using token_credential auth ({credentials.credential_class})")
+                accessToken = get_token_credential_access_token(credentials)
             else:
                 logger.info("Using SPN auth")
                 accessToken = get_sp_access_token(credentials)

--- a/src/dbt/adapters/fabricspark/livysession.py
+++ b/src/dbt/adapters/fabricspark/livysession.py
@@ -199,11 +199,23 @@ def get_default_access_token(credentials: FabricSparkCredentials) -> AccessToken
 
 
 def _load_custom_credential(credentials: FabricSparkCredentials) -> Any:
-    """Import and instantiate the user-supplied TokenCredential.
+    """
+    Import and instantiate the user-supplied TokenCredential.
 
     The instance is cached per (dotted_path, kwargs) tuple so that refresh
     cycles reuse the same object (matching how azure-identity credentials
     are typically held).
+
+    Parameters
+    ----------
+    credentials : FabricSparkCredentials
+        Credentials carrying ``credential_class`` (dotted path) and
+        ``credential_kwargs``.
+
+    Returns
+    -------
+    out : Any
+        An instance of the user-supplied TokenCredential implementation.
     """
     dotted = credentials.credential_class
     if not dotted:
@@ -257,11 +269,21 @@ def _load_custom_credential(credentials: FabricSparkCredentials) -> Any:
 
 
 def get_token_credential_access_token(credentials: FabricSparkCredentials) -> AccessToken:
-    """Get an access token from a user-supplied TokenCredential class.
+    """
+    Get an Azure access token from a user-supplied TokenCredential class.
 
-    Loaded by dotted path from ``credentials.credential_class`` and
-    instantiated with ``credentials.credential_kwargs``. See discussion
-    https://github.com/microsoft/dbt-fabricspark/discussions/166.
+    The class is loaded by dotted path from ``credentials.credential_class``
+    and instantiated with ``credentials.credential_kwargs``.
+
+    Parameters
+    ----------
+    credentials : FabricSparkCredentials
+        Credentials.
+
+    Returns
+    -------
+    out : AccessToken
+        The access token returned by the user-supplied credential.
     """
     credential = _load_custom_credential(credentials)
     result = credential.get_token(AZURE_CREDENTIAL_SCOPE)

--- a/src/dbt/include/fabricspark/profile_template.yml
+++ b/src/dbt/include/fabricspark/profile_template.yml
@@ -14,13 +14,17 @@ prompts:
         default: https://api.fabric.microsoft.com/v1
       auth:
         default: CLI
-        hint: Use CLI (az login) for interactive execution or SPN for automation
+        hint: One of CLI (az login), SPN (client_id/secret/tenant), fabric_notebook, or token_credential (custom TokenCredential)
       client_id:
         hint: Use when SPN auth is used.
       client_secret:
         hint: Use when SPN auth is used.
       tenant_id:
         hint: Use when SPN auth is used.
+      credential_class:
+        hint: Use when token_credential auth is used. Dotted path to a class implementing azure.core.credentials.TokenCredential (e.g. my_pkg.auth.ExternalTokenCredential).
+      credential_kwargs:
+        hint: Use when token_credential auth is used. Mapping of kwargs passed to credential_class on instantiation.
       connect_retries:
         default: 0
         type: 'int'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,7 +183,7 @@ def _profile_token_credential_target():
     Uses a thin wrapper around AzureCliCredential (declared in the test
     module) so the dotted path is importable and we still get a real Fabric
     token locally. CI doesn't run this profile — it's for local smoke tests
-    against the contributor's own Fabric workspace (see discussion #166).
+    against the contributor's own Fabric workspace.
     """
     spark_config = {
         "name": os.getenv("SESSION_NAME", "example-session"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,8 @@ def dbt_profile_target(request):
         target = _profile_azure_spn_target()
     elif profile_type == "int_tests":
         target = _profile_int_tests_target()
+    elif profile_type == "token_credential":
+        target = _profile_token_credential_target()
     else:
         raise ValueError(f"Invalid profile type '{profile_type}'")
     return target
@@ -170,6 +172,34 @@ def _profile_azure_spn_target():
             "client_id": os.getenv("DBT_AZURE_SP_NAME"),
             "client_secret": os.getenv("DBT_AZURE_SP_SECRET"),
             "tenant_id": os.getenv("DBT_AZURE_TENANT"),
+        },
+        **{"spark_config": spark_config},
+    }
+
+
+def _profile_token_credential_target():
+    """Profile that exercises the token_credential auth path end-to-end.
+
+    Uses a thin wrapper around AzureCliCredential (declared in the test
+    module) so the dotted path is importable and we still get a real Fabric
+    token locally. CI doesn't run this profile — it's for local smoke tests
+    against the contributor's own Fabric workspace (see discussion #166).
+    """
+    spark_config = {
+        "name": os.getenv("SESSION_NAME", "example-session"),
+        "tags": {
+            "project": os.getenv("SESSION_NAME", "example-session"),
+            "user": "pvenkat@microsoft.com",
+        },
+    }
+    return {
+        **_all_profiles_base(),
+        **{
+            "authentication": "token_credential",
+            "credential_class": (
+                "tests.functional.adapter.test_token_credential.AzureCliBackedCredential"
+            ),
+            "credential_kwargs": {},
         },
         **{"spark_config": spark_config},
     }

--- a/tests/functional/adapter/test_token_credential.py
+++ b/tests/functional/adapter/test_token_credential.py
@@ -6,7 +6,7 @@ Run locally against your own Fabric workspace:
         tests/functional/adapter/test_token_credential.py
 
 CI does not exercise this profile — it's intended for contributor smoke
-testing per the contrib workflow (discussion #166).
+testing per the contrib workflow.
 """
 
 import pytest

--- a/tests/functional/adapter/test_token_credential.py
+++ b/tests/functional/adapter/test_token_credential.py
@@ -1,0 +1,47 @@
+"""End-to-end smoke test for the `token_credential` auth method.
+
+Run locally against your own Fabric workspace:
+
+    uv run pytest --profile token_credential \
+        tests/functional/adapter/test_token_credential.py
+
+CI does not exercise this profile — it's intended for contributor smoke
+testing per the contrib workflow (discussion #166).
+"""
+
+import pytest
+from azure.core.credentials import AccessToken, TokenCredential
+
+from dbt.tests.util import run_dbt
+
+
+class AzureCliBackedCredential(TokenCredential):
+    """Thin TokenCredential that delegates to AzureCliCredential.
+
+    Exists so the functional smoke test has a real, importable dotted-path
+    credential that produces a valid Fabric token without requiring the
+    contributor to stand up a separate broker. Mimics the shape of what a
+    real user-supplied credential would look like.
+    """
+
+    def __init__(self, **kwargs):
+        from azure.identity import AzureCliCredential
+
+        self._inner = AzureCliCredential(**kwargs)
+
+    def get_token(self, *scopes, **kwargs) -> AccessToken:
+        return self._inner.get_token(*scopes, **kwargs)
+
+
+@pytest.mark.skip_profile("az_cli", "azure_spn", "int_tests")
+class TestTokenCredentialAuth:
+    """Smoke test: a custom TokenCredential drives a real Fabric Livy session."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"hello.sql": "select 1 as id"}
+
+    def test_dbt_run_under_token_credential(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -354,6 +354,16 @@ def dbt_profile_target(request, workspace_id, api_endpoint, schema_mode):
     if profile_type == "int_tests":
         base["authentication"] = "int_tests"
         base["accessToken"] = os.getenv("FABRIC_INTEGRATION_TESTS_TOKEN")
+    elif profile_type == "token_credential":
+        # End-to-end smoke for discussion #166. The dotted path points at a
+        # thin wrapper around AzureCliCredential declared in the test module,
+        # so it produces a real Fabric token locally without requiring a
+        # separate broker.
+        base["authentication"] = "token_credential"
+        base["credential_class"] = (
+            "tests.functional.adapter.test_token_credential.AzureCliBackedCredential"
+        )
+        base["credential_kwargs"] = {}
     else:
         base["authentication"] = "CLI"
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -355,10 +355,9 @@ def dbt_profile_target(request, workspace_id, api_endpoint, schema_mode):
         base["authentication"] = "int_tests"
         base["accessToken"] = os.getenv("FABRIC_INTEGRATION_TESTS_TOKEN")
     elif profile_type == "token_credential":
-        # End-to-end smoke for discussion #166. The dotted path points at a
-        # thin wrapper around AzureCliCredential declared in the test module,
-        # so it produces a real Fabric token locally without requiring a
-        # separate broker.
+        # The dotted path points at a thin wrapper around AzureCliCredential
+        # declared in the test module, so the smoke test produces a real
+        # Fabric token locally without requiring a separate broker.
         base["authentication"] = "token_credential"
         base["credential_class"] = (
             "tests.functional.adapter.test_token_credential.AzureCliBackedCredential"

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -414,20 +414,24 @@ def test_credential_kwargs_with_non_token_auth_raises() -> None:
 
 def test_repr_masks_credential_kwargs_values() -> None:
     """__repr__ must not leak credential_kwargs values (broker URLs, user ids)."""
-    secret_value = "secret-broker.internal/token"
+    # Bind both fixture values to named constants so any future change to
+    # the fixture stays in lockstep with the assertions below.
+    SECRET_URL = "secret-broker.internal/token"
+    SECRET_USER_ID = "user-123"
     credentials = FabricSparkCredentials(
         authentication="token_credential",
         credential_class="my_pkg.auth.Cred",
         # Two value shapes: a URL-like string and a plain scalar. We want
         # both kinds masked so the redaction isn't accidentally only
         # matching things that look like URLs.
-        credential_kwargs={"token_url": secret_value, "user_id": "user-123"},
+        credential_kwargs={"token_url": SECRET_URL, "user_id": SECRET_USER_ID},
         **_base_fabric_kwargs(),
     )
     rendered = repr(credentials)
-    assert secret_value not in rendered
-    assert "user-123" not in rendered
-    # Keys should still appear so operators can debug shape mismatches.
+    # Values must be redacted; keys must still appear so operators can
+    # debug shape mismatches.
+    assert SECRET_URL not in rendered
+    assert SECRET_USER_ID not in rendered
     assert "token_url" in rendered
     assert "user_id" in rendered
     assert "my_pkg.auth.Cred" in rendered

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -344,3 +344,87 @@ def test_permanent_error_case_insensitive() -> None:
         "Error while executing query: [schema_not_found] The schema `foo` cannot be found."
     )
     assert _is_permanent_error(exc) is True
+
+
+# --- Tests for token_credential auth (discussion #166) ---
+
+
+def _base_fabric_kwargs() -> dict:
+    return {
+        "method": "livy",
+        "lakehouse": "tests",
+        "workspaceid": "1de8390c-9aca-4790-bee8-72049109c0f4",
+        "lakehouseid": "8c5bc260-bc3a-4898-9ada-01e433d461ba",
+        "spark_config": {"name": "test-session"},
+    }
+
+
+def test_token_credential_requires_credential_class() -> None:
+    """authentication=token_credential without credential_class must raise."""
+    with pytest.raises(DbtRuntimeError, match="credential_class"):
+        FabricSparkCredentials(
+            authentication="token_credential",
+            **_base_fabric_kwargs(),
+        )
+
+
+def test_token_credential_accepts_dotted_path() -> None:
+    credentials = FabricSparkCredentials(
+        authentication="token_credential",
+        credential_class="my_pkg.auth.ExternalTokenCredential",
+        credential_kwargs={"token_url": "https://broker.internal/token", "user_id": "alice"},
+        **_base_fabric_kwargs(),
+    )
+    assert credentials.credential_class == "my_pkg.auth.ExternalTokenCredential"
+    assert credentials.credential_kwargs == {
+        "token_url": "https://broker.internal/token",
+        "user_id": "alice",
+    }
+
+
+def test_token_credential_case_insensitive() -> None:
+    """authentication value should be matched case-insensitively."""
+    credentials = FabricSparkCredentials(
+        authentication="Token_Credential",
+        credential_class="my_pkg.auth.Cred",
+        **_base_fabric_kwargs(),
+    )
+    assert credentials.credential_class == "my_pkg.auth.Cred"
+
+
+def test_credential_class_with_non_token_auth_raises() -> None:
+    """credential_class set but authentication != token_credential must raise."""
+    with pytest.raises(DbtRuntimeError, match="token_credential"):
+        FabricSparkCredentials(
+            authentication="CLI",
+            credential_class="my_pkg.auth.Cred",
+            **_base_fabric_kwargs(),
+        )
+
+
+def test_credential_kwargs_with_non_token_auth_raises() -> None:
+    """credential_kwargs set but authentication != token_credential must raise."""
+    with pytest.raises(DbtRuntimeError, match="token_credential"):
+        FabricSparkCredentials(
+            authentication="CLI",
+            credential_kwargs={"token_url": "https://x"},
+            **_base_fabric_kwargs(),
+        )
+
+
+def test_repr_masks_credential_kwargs_values() -> None:
+    """__repr__ must not leak credential_kwargs values (broker URLs, user ids)."""
+    secret_value = "secret-broker.internal/token"
+    credentials = FabricSparkCredentials(
+        authentication="token_credential",
+        credential_class="my_pkg.auth.Cred",
+        credential_kwargs={"token_url": secret_value, "user_id": "alice"},
+        **_base_fabric_kwargs(),
+    )
+    rendered = repr(credentials)
+    assert secret_value not in rendered
+    assert "alice" not in rendered
+    # Keys should still appear so operators can debug shape mismatches.
+    assert "token_url" in rendered
+    assert "user_id" in rendered
+    assert "my_pkg.auth.Cred" in rendered

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -346,15 +346,15 @@ def test_permanent_error_case_insensitive() -> None:
     assert _is_permanent_error(exc) is True
 
 
-# --- Tests for token_credential auth (discussion #166) ---
+# --- Tests for token_credential auth ---
 
 
 def _base_fabric_kwargs() -> dict:
     return {
         "method": "livy",
         "lakehouse": "tests",
-        "workspaceid": "1de8390c-9aca-4790-bee8-72049109c0f4",
-        "lakehouseid": "8c5bc260-bc3a-4898-9ada-01e433d461ba",
+        "workspaceid": "00000000-0000-0000-0000-000000000000",
+        "lakehouseid": "00000000-0000-0000-0000-000000000001",
         "spark_config": {"name": "test-session"},
     }
 
@@ -418,12 +418,15 @@ def test_repr_masks_credential_kwargs_values() -> None:
     credentials = FabricSparkCredentials(
         authentication="token_credential",
         credential_class="my_pkg.auth.Cred",
-        credential_kwargs={"token_url": secret_value, "user_id": "alice"},
+        # Two value shapes: a URL-like string and a plain scalar. We want
+        # both kinds masked so the redaction isn't accidentally only
+        # matching things that look like URLs.
+        credential_kwargs={"token_url": secret_value, "user_id": "user-123"},
         **_base_fabric_kwargs(),
     )
     rendered = repr(credentials)
     assert secret_value not in rendered
-    assert "alice" not in rendered
+    assert "user-123" not in rendered
     # Keys should still appear so operators can debug shape mismatches.
     assert "token_url" in rendered
     assert "user_id" in rendered

--- a/tests/unit/test_livysession.py
+++ b/tests/unit/test_livysession.py
@@ -846,7 +846,7 @@ class TestFetchmany:
         assert cursor.fetchone() == ("c",)
 
 
-# --- Tests for token_credential auth path (discussion #166) ---
+# --- Tests for token_credential auth path ---
 
 
 class _StaticFakeCredential:
@@ -892,8 +892,8 @@ def _make_token_credential_creds(credential_class: str, kwargs: dict | None = No
         credential_class=credential_class,
         credential_kwargs=kwargs or {},
         lakehouse="tests",
-        workspaceid="1de8390c-9aca-4790-bee8-72049109c0f4",
-        lakehouseid="8c5bc260-bc3a-4898-9ada-01e433d461ba",
+        workspaceid="00000000-0000-0000-0000-000000000000",
+        lakehouseid="00000000-0000-0000-0000-000000000001",
         spark_config={"name": "test-session"},
     )
 

--- a/tests/unit/test_livysession.py
+++ b/tests/unit/test_livysession.py
@@ -844,3 +844,209 @@ class TestFetchmany:
         assert cursor._fetch_index == 0
         # fetchone() should return the first (only) row of the new result
         assert cursor.fetchone() == ("c",)
+
+
+# --- Tests for token_credential auth path (discussion #166) ---
+
+
+class _StaticFakeCredential:
+    """Module-level fake TokenCredential so the dotted path can be imported."""
+
+    last_kwargs: dict = {}
+    call_count: int = 0
+
+    def __init__(self, **kwargs):
+        type(self).last_kwargs = kwargs
+
+    def get_token(self, *scopes, **kwargs):
+        from azure.core.credentials import AccessToken
+
+        type(self).call_count += 1
+        return AccessToken(token="fake-token", expires_on=9999999999)
+
+
+class _NotACredential:
+    """Class without get_token — should be rejected by the loader."""
+
+    def __init__(self, **kwargs):
+        pass
+
+
+def _reset_token_state():
+    """Wipe the module-level access token and credential cache between tests."""
+    import dbt.adapters.fabricspark.livysession as livysession_module
+
+    livysession_module.accessToken = None
+    livysession_module._custom_credential_cache.clear()
+    _StaticFakeCredential.call_count = 0
+    _StaticFakeCredential.last_kwargs = {}
+
+
+def _make_token_credential_creds(credential_class: str, kwargs: dict | None = None):
+    from dbt.adapters.fabricspark.credentials import FabricSparkCredentials
+
+    return FabricSparkCredentials(
+        method="livy",
+        livy_mode="fabric",
+        authentication="token_credential",
+        credential_class=credential_class,
+        credential_kwargs=kwargs or {},
+        lakehouse="tests",
+        workspaceid="1de8390c-9aca-4790-bee8-72049109c0f4",
+        lakehouseid="8c5bc260-bc3a-4898-9ada-01e433d461ba",
+        spark_config={"name": "test-session"},
+    )
+
+
+class TestTokenCredentialAuth:
+    def test_get_headers_uses_custom_credential(self):
+        _reset_token_state()
+        from dbt.adapters.fabricspark.livysession import get_headers
+
+        credentials = _make_token_credential_creds(
+            "tests.unit.test_livysession._StaticFakeCredential",
+            {"token_url": "https://broker.example/token"},
+        )
+        headers = get_headers(credentials)
+
+        assert headers["Authorization"] == "Bearer fake-token"
+        assert _StaticFakeCredential.last_kwargs == {"token_url": "https://broker.example/token"}
+        assert _StaticFakeCredential.call_count == 1
+
+    def test_credential_instance_is_cached_across_calls(self):
+        _reset_token_state()
+        from dbt.adapters.fabricspark.livysession import _load_custom_credential
+
+        credentials = _make_token_credential_creds(
+            "tests.unit.test_livysession._StaticFakeCredential",
+            {"token_url": "https://broker.example/token"},
+        )
+        first = _load_custom_credential(credentials)
+        second = _load_custom_credential(credentials)
+        assert first is second
+
+    def test_unknown_module_raises_runtime_error(self):
+        _reset_token_state()
+        from dbt_common.exceptions import DbtRuntimeError
+
+        from dbt.adapters.fabricspark.livysession import _load_custom_credential
+
+        credentials = _make_token_credential_creds("nonexistent_pkg.module.Cls")
+        with pytest.raises(DbtRuntimeError, match="Could not import module"):
+            _load_custom_credential(credentials)
+
+    def test_missing_attribute_raises_runtime_error(self):
+        _reset_token_state()
+        from dbt_common.exceptions import DbtRuntimeError
+
+        from dbt.adapters.fabricspark.livysession import _load_custom_credential
+
+        credentials = _make_token_credential_creds(
+            "tests.unit.test_livysession.DoesNotExistOnModule",
+        )
+        with pytest.raises(DbtRuntimeError, match="has no attribute"):
+            _load_custom_credential(credentials)
+
+    def test_non_dotted_path_raises_runtime_error(self):
+        _reset_token_state()
+        from dbt_common.exceptions import DbtRuntimeError
+
+        from dbt.adapters.fabricspark.livysession import _load_custom_credential
+
+        credentials = _make_token_credential_creds("notdotted")
+        with pytest.raises(DbtRuntimeError, match="dotted path"):
+            _load_custom_credential(credentials)
+
+    def test_instance_without_get_token_raises_runtime_error(self):
+        _reset_token_state()
+        from dbt_common.exceptions import DbtRuntimeError
+
+        from dbt.adapters.fabricspark.livysession import _load_custom_credential
+
+        credentials = _make_token_credential_creds(
+            "tests.unit.test_livysession._NotACredential",
+        )
+        with pytest.raises(DbtRuntimeError, match="get_token"):
+            _load_custom_credential(credentials)
+
+    def test_get_token_must_return_access_token(self):
+        """A credential whose get_token returns a non-AccessToken must fail loud."""
+        _reset_token_state()
+        from dbt_common.exceptions import DbtRuntimeError
+
+        from dbt.adapters.fabricspark.livysession import get_token_credential_access_token
+
+        credentials = _make_token_credential_creds(
+            "tests.unit.test_livysession._BadReturnTypeCredential",
+        )
+        with pytest.raises(DbtRuntimeError, match="AccessToken"):
+            get_token_credential_access_token(credentials)
+
+    def test_dotted_path_with_invalid_chars_rejected(self):
+        """Defence-in-depth: dotted path is validated against an identifier regex."""
+        _reset_token_state()
+        from dbt_common.exceptions import DbtRuntimeError
+
+        from dbt.adapters.fabricspark.livysession import _load_custom_credential
+
+        for bad in [
+            "pkg.module;os.system",
+            "pkg/module.Cls",
+            "pkg..Cls",
+            ".pkg.Cls",
+            "pkg.Cls.",
+            "1pkg.Cls",
+        ]:
+            credentials = _make_token_credential_creds(bad)
+            with pytest.raises(DbtRuntimeError, match="dotted path"):
+                _load_custom_credential(credentials)
+
+    def test_kwargs_with_unhashable_values_cache_correctly(self):
+        """Nested dict/list kwargs (from YAML) must not break the cache key."""
+        _reset_token_state()
+        from dbt.adapters.fabricspark.livysession import _load_custom_credential
+
+        credentials = _make_token_credential_creds(
+            "tests.unit.test_livysession._StaticFakeCredential",
+            {"opts": {"nested": "x"}, "tags": ["a", "b"]},
+        )
+        first = _load_custom_credential(credentials)
+        second = _load_custom_credential(credentials)
+        assert first is second
+
+    def test_token_refresh_reinvokes_get_token(self):
+        """When the cached AccessToken is near expiry, get_headers must refetch."""
+        _reset_token_state()
+        import dbt.adapters.fabricspark.livysession as livysession_module
+        from dbt.adapters.fabricspark.livysession import get_headers
+
+        credentials = _make_token_credential_creds(
+            "tests.unit.test_livysession._StaticFakeCredential",
+        )
+
+        # First call: cold — fetches a token.
+        get_headers(credentials)
+        assert _StaticFakeCredential.call_count == 1
+
+        # Second call: token still valid — no refresh.
+        get_headers(credentials)
+        assert _StaticFakeCredential.call_count == 1
+
+        # Force expiry: set the module-global token to one that's already
+        # expired so is_token_refresh_necessary fires.
+        from azure.core.credentials import AccessToken
+
+        livysession_module.accessToken = AccessToken(token="stale", expires_on=0)
+
+        get_headers(credentials)
+        assert _StaticFakeCredential.call_count == 2
+
+
+class _BadReturnTypeCredential:
+    """Returns a plain string instead of AccessToken — caught by isinstance guard."""
+
+    def __init__(self, **kwargs):
+        pass
+
+    def get_token(self, *scopes, **kwargs):
+        return "not-an-access-token"


### PR DESCRIPTION
Closes #166.

Adds a `token_credential` auth method that loads any `azure.core.credentials.TokenCredential` implementation by dotted path. Useful when callers already have a token source the adapter doesn't know about: desktop tools with their own OAuth flow, WIF in CI, Vault brokers, etc. Avoids forcing a second `az login` or repurposing the SPN config.

Profile shape:

```yml
dev:
  type: fabricspark
  method: livy
  authentication: token_credential
  credential_class: "my_pkg.auth.MyCredential"
  credential_kwargs:
    token_url: "{{ env_var('TOKEN_URL') }}"
    user_id:   "{{ env_var('USER_ID') }}"
  workspaceid: ...
  lakehouseid: ...
  lakehouse: ...
```

At connect time the adapter imports the dotted path, instantiates the class with `credential_kwargs`, and calls `get_token()`. The existing token-refresh path picks up new tokens automatically.

### What's in the diff

* `FabricSparkCredentials` gets two new optional fields, `credential_class` and `credential_kwargs`. Validation rejects either half being set with a different auth, and `token_credential` without a class.
* `__repr__` shows the sorted key list of `credential_kwargs` but not the values (they may contain secrets).
* `_load_custom_credential` in `livysession.py` does the importlib + instantiate + `isinstance(TokenCredential)` check. The instance is cached per (path, kwargs) so refresh cycles reuse it. `TokenCredential` is a runtime-checkable Protocol, so isinstance is enough no separate duck-type fallback.
* `isinstance(result, AccessToken)` check on `get_token()`'s return so bad implementations fail with a clear message rather than an `AttributeError` later.
* New branch in `get_headers` for `token_credential`, between `fabric_notebook` and the SPN fallback.
* Profile template + CHANGELOG entry.

### Security

`credential_kwargs` values are passed through unchanged to the credential class and may contain secrets. The CHANGELOG entry calls this out and recommends `{{ env_var(...) }}` plus restricted `profiles.yml` permissions. The dotted path is INFO-logged on each new token fetch; the token itself stays out of logs (existing `tokenPrint=True` debug flag is unchanged).

### Tests

* 12 new unit tests covering validation, repr masking, the loader cache, the refresh path, and every error branch (unknown module, missing attribute, non-dotted path, no `get_token`, non-`AccessToken` return, unhashable nested kwargs).
* Functional smoke test under `--profile token_credential` that runs one dbt model against real Fabric using a thin `AzureCliCredential` wrapper as the dotted-path target. Skipped in CI's default `az_cli` profile.

Local CI status:

* [x] Unit suite green in the files I touched (88 tests).
* [x] `ruff check --fix && ruff format --check` clean.
* [x] `uv build` + `twine check` clean.
* [x] CLI functional smoke against my Fabric workspace existing path still works.
* [x] `token_credential` functional smoke against my Fabric workspace.
* [x] End-to-end with a separate standalone credential package shelling out to `az account get-access-token`, dropped into a normal dbt project. Confirmed kwargs forward intact (including non-string types), `get_token` is invoked, and a deliberately-bogus token produces a 401 from Fabric (no silent fallback).
* [ ] CI on the upstream Fabric workspace please run when ready, can't trigger this myself.
