### PR TITLE
fix: cross-workspace view/snapshot/MLV materializations omit workspace prefix (#172)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,11 @@ uv run pytest tests/unit/test_adapter.py::TestSparkAdapter::test_profile_with_da
 - **`fail-on-untracked-files` will fail CI if you leave a regenerated file uncommitted** — this catches stale `uv.lock` after a dep change. Always commit lockfile updates that result from your edits.
 - **Devcontainer image is pinned by digest** in `.devcontainer/devcontainer.json` and `.github/workflows/ci.yml`. Don't hand-edit these; rebuild via the flow in `.devcontainer/README.md`.
 
+## Comments in code
+
+- Do **NOT** add flowery comments in the code all over the place. The code is self-descriptive, **ONLY** add comments when the code is doing something non-orthodox
+- Do **NOT** indirectly refer to Github issues in the actual code. The codebase has nothing to do with Github, it's self-contained.
+
 ## Do not assume — ask first
 
 Adapter behavior is subtle (schema-enabled detection, cross-lakehouse routing, session reuse, MLV semantics, Livy retry policy). Before making non-trivial changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   IS_GH_ACTION: "1"
   CLIENT_ID: ${{ secrets.APP_ID }}

--- a/src/dbt/include/fabricspark/macros/materializations/models/materialized_lake_view/materialized_lake_view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/materialized_lake_view/materialized_lake_view.sql
@@ -33,11 +33,6 @@
 
 {% materialization materialized_lake_view, adapter='fabricspark' -%}
     {%- set identifier = model['alias'] -%}
-    {#-- Cross-workspace 4-part naming: forward `workspace_name` onto the
-         target relation so the rendered CREATE/REPLACE/DROP DDL emits the
-         4-part name (parity with table/view/incremental/snapshot). The MLV
-         REST API path resolves lakehouse IDs against the profile workspace;
-         cross-workspace MLV via REST is a separate concern. --#}
     {%- set workspace_name = config.get('workspace_name') -%}
 
     {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}

--- a/src/dbt/include/fabricspark/macros/materializations/models/materialized_lake_view/materialized_lake_view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/materialized_lake_view/materialized_lake_view.sql
@@ -33,13 +33,20 @@
 
 {% materialization materialized_lake_view, adapter='fabricspark' -%}
     {%- set identifier = model['alias'] -%}
+    {#-- Cross-workspace 4-part naming: forward `workspace_name` onto the
+         target relation so the rendered CREATE/REPLACE/DROP DDL emits the
+         4-part name (parity with table/view/incremental/snapshot). The MLV
+         REST API path resolves lakehouse IDs against the profile workspace;
+         cross-workspace MLV via REST is a separate concern. --#}
+    {%- set workspace_name = config.get('workspace_name') -%}
 
     {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
     {%- set target_relation = api.Relation.create(
             identifier=identifier,
             schema=schema,
             database=database,
-            type='materialized_view') -%}
+            type='materialized_view',
+            workspace=workspace_name) -%}
 
     {#-- Config --#}
     {%- set partitioned_by = config.get('partitioned_by', none) -%}

--- a/src/dbt/include/fabricspark/macros/materializations/models/view/mv.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view/mv.sql
@@ -1,7 +1,45 @@
 {% materialization view, adapter='fabricspark' -%}
-    {#-- Ensure the database/schema exists before creating the view --#}
-    {% do ensure_database_exists(model.schema, database=model.database, workspace=model.config.get('workspace_name')) %}
-    {{ return(create_or_replace_view()) }}
+    {%- set identifier = model['alias'] -%}
+    {%- set grant_config = config.get('grants') -%}
+    {#-- Cross-workspace 4-part naming: when the model sets `workspace_name`,
+         carry it through to the target relation so the rendered DDL emits the
+         4-part name and Fabric Livy routes the CREATE VIEW to the correct
+         workspace catalog. Mirrors the table materialization. --#}
+    {%- set workspace_name = config.get('workspace_name') -%}
+
+    {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+    {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
+
+    {%- set target_relation = api.Relation.create(
+        identifier=identifier, schema=schema, database=database,
+        type='view', workspace=workspace_name) -%}
+
+    {#-- Ensure the database/schema exists before creating the view. For
+         cross-workspace writes the ``workspace_name`` is forwarded so the
+         rendered DDL is workspace-qualified
+         (``CREATE DATABASE IF NOT EXISTS \`WS2\`.\`lh\`.\`schema\```). --#}
+    {% do ensure_database_exists(schema, database=database, workspace=workspace_name) %}
+
+    {{ run_hooks(pre_hooks) }}
+
+    {#-- If there's a table with the same name, drop it via the fabricspark
+         handler (also clears any auto-discovered view metadata). --#}
+    {%- if old_relation is not none and old_relation.is_table -%}
+      {{ fabricspark__handle_existing_table(should_full_refresh(), old_relation) }}
+    {%- endif -%}
+
+    {% call statement('main') -%}
+      {{ get_create_view_as_sql(target_relation, sql) }}
+    {%- endcall %}
+
+    {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
+    {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+    {% do persist_docs(target_relation, model) %}
+
+    {{ run_hooks(post_hooks) }}
+
+    {{ return({'relations': [target_relation]}) }}
 {%- endmaterialization %}
 
 {% macro fabricspark__handle_existing_table(full_refresh, old_relation) %}

--- a/src/dbt/include/fabricspark/macros/materializations/models/view/mv.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view/mv.sql
@@ -1,10 +1,6 @@
 {% materialization view, adapter='fabricspark' -%}
     {%- set identifier = model['alias'] -%}
     {%- set grant_config = config.get('grants') -%}
-    {#-- Cross-workspace 4-part naming: when the model sets `workspace_name`,
-         carry it through to the target relation so the rendered DDL emits the
-         4-part name and Fabric Livy routes the CREATE VIEW to the correct
-         workspace catalog. Mirrors the table materialization. --#}
     {%- set workspace_name = config.get('workspace_name') -%}
 
     {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
@@ -14,16 +10,10 @@
         identifier=identifier, schema=schema, database=database,
         type='view', workspace=workspace_name) -%}
 
-    {#-- Ensure the database/schema exists before creating the view. For
-         cross-workspace writes the ``workspace_name`` is forwarded so the
-         rendered DDL is workspace-qualified
-         (``CREATE DATABASE IF NOT EXISTS \`WS2\`.\`lh\`.\`schema\```). --#}
     {% do ensure_database_exists(schema, database=database, workspace=workspace_name) %}
 
     {{ run_hooks(pre_hooks) }}
 
-    {#-- If there's a table with the same name, drop it via the fabricspark
-         handler (also clears any auto-discovered view metadata). --#}
     {%- if old_relation is not none and old_relation.is_table -%}
       {{ fabricspark__handle_existing_table(should_full_refresh(), old_relation) }}
     {%- endif -%}

--- a/src/dbt/include/fabricspark/macros/materializations/models/view/mv.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view/mv.sql
@@ -25,8 +25,6 @@
     {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
     {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
-    {% do persist_docs(target_relation, model) %}
-
     {{ run_hooks(post_hooks) }}
 
     {{ return({'relations': [target_relation]}) }}

--- a/src/dbt/include/fabricspark/macros/materializations/snapshots/snapshot.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/snapshots/snapshot.sql
@@ -39,9 +39,7 @@
     {% set tmp_identifier = target_relation.identifier ~ '__dbt_tmp' %}
 
     {#-- Persisted view (non-temp) so that its columns can be ascertained via `describe`.
-         Inherits database/schema/workspace from target_relation so cross-workspace
-         snapshots (workspace_name set in config) emit a 4-part staging view that
-         lives in the same workspace catalog as the MERGE target. --#}
+         Inherits database/schema from target_relation for proper 2-part or 3-part naming. --#}
     {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier,
                                               schema=target_relation.schema,
                                               database=target_relation.database,
@@ -86,10 +84,6 @@
   {%- set unique_key = config.get('unique_key') %}
   {%- set file_format = config.get('file_format') or 'delta' -%}
   {%- set grant_config = config.get('grants') -%}
-  {#-- Cross-workspace 4-part naming: when the snapshot sets `workspace_name`,
-       forward it onto the target_relation so the rendered CTAS / MERGE INTO
-       emits the 4-part name and Fabric Livy routes the DDL to the correct
-       workspace catalog. Mirrors the table/incremental materializations. --#}
   {%- set workspace_name = config.get('workspace_name') -%}
 
   {% set target_relation_exists, target_relation = get_or_create_relation(
@@ -98,12 +92,6 @@
           identifier=target_table,
           type='table') -%}
 
-  {#-- ``get_or_create_relation`` (default dispatch) returns a relation that
-       carries no ``workspace`` field — neither the cache lookup nor the
-       fallback ``api.Relation.create`` propagate it. Re-incorporate workspace
-       so downstream CTAS / MERGE / staging-view rendering emits the 4-part
-       name. ``incorporate`` round-trips through ``from_dict`` which preserves
-       the ``workspace`` field on ``FabricSparkRelation``. --#}
   {%- if workspace_name -%}
     {% set target_relation = target_relation.incorporate(workspace=workspace_name) %}
   {%- endif -%}

--- a/src/dbt/include/fabricspark/macros/materializations/snapshots/snapshot.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/snapshots/snapshot.sql
@@ -39,10 +39,13 @@
     {% set tmp_identifier = target_relation.identifier ~ '__dbt_tmp' %}
 
     {#-- Persisted view (non-temp) so that its columns can be ascertained via `describe`.
-         Inherits database/schema from target_relation for proper 2-part or 3-part naming. --#}
+         Inherits database/schema/workspace from target_relation so cross-workspace
+         snapshots (workspace_name set in config) emit a 4-part staging view that
+         lives in the same workspace catalog as the MERGE target. --#}
     {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier,
                                               schema=target_relation.schema,
                                               database=target_relation.database,
+                                              workspace=target_relation.workspace,
                                               type='view') -%}
 
     {% set select = snapshot_staging_table(strategy, sql, target_relation) %}
@@ -83,12 +86,27 @@
   {%- set unique_key = config.get('unique_key') %}
   {%- set file_format = config.get('file_format') or 'delta' -%}
   {%- set grant_config = config.get('grants') -%}
+  {#-- Cross-workspace 4-part naming: when the snapshot sets `workspace_name`,
+       forward it onto the target_relation so the rendered CTAS / MERGE INTO
+       emits the 4-part name and Fabric Livy routes the DDL to the correct
+       workspace catalog. Mirrors the table/incremental materializations. --#}
+  {%- set workspace_name = config.get('workspace_name') -%}
 
   {% set target_relation_exists, target_relation = get_or_create_relation(
           database=model.database,
           schema=model.schema,
           identifier=target_table,
           type='table') -%}
+
+  {#-- ``get_or_create_relation`` (default dispatch) returns a relation that
+       carries no ``workspace`` field — neither the cache lookup nor the
+       fallback ``api.Relation.create`` propagate it. Re-incorporate workspace
+       so downstream CTAS / MERGE / staging-view rendering emits the 4-part
+       name. ``incorporate`` round-trips through ``from_dict`` which preserves
+       the ``workspace`` field on ``FabricSparkRelation``. --#}
+  {%- if workspace_name -%}
+    {% set target_relation = target_relation.incorporate(workspace=workspace_name) %}
+  {%- endif -%}
 
   {%- if file_format not in ['delta'] -%}
     {% set invalid_format_msg -%}

--- a/tests/functional/adapter/test_cross_workspace.py
+++ b/tests/functional/adapter/test_cross_workspace.py
@@ -570,7 +570,7 @@ class TestCrossWorkspace4PartWriteIncremental:
 
 
 # ---------------------------------------------------------------------------
-# Positive: cross-workspace WRITE via VIEW materialization (issue #172)
+# Positive: cross-workspace WRITE via VIEW materialization
 # ---------------------------------------------------------------------------
 
 

--- a/tests/functional/adapter/test_cross_workspace.py
+++ b/tests/functional/adapter/test_cross_workspace.py
@@ -567,3 +567,356 @@ class TestCrossWorkspace4PartWriteIncremental:
             "expected 4 rows after cross-workspace --full-refresh "
             f"(reset to first-run body), got {n}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Positive: cross-workspace WRITE via VIEW materialization (issue #172)
+# ---------------------------------------------------------------------------
+
+
+# A model whose physical view lives in WS2. Mirrors ``CROSS_WS_WRITE_TABLE_SQL``
+# but materialized as ``view``. Regression coverage for issue #172 where
+# ``workspace_name`` was not forwarded from the model config to
+# ``target_relation``, so the rendered DDL emitted only a 3-part name and
+# Fabric Livy returned ``Artifact not found`` because it tried to resolve the
+# lakehouse inside the *current* workspace.
+CROSS_WS_WRITE_VIEW_SQL = """
+{{ config(
+    materialized='view',
+    workspace_name=var('ws2_workspace_name'),
+    database=var('ws2_lakehouse_name'),
+    schema=var('ws2_write_schema')
+) }}
+
+select 1 as id, 'alpha' as name, cast(10.5 as double) as price
+union all
+select 2 as id, 'beta'  as name, cast(20.0 as double) as price
+union all
+select 3 as id, 'gamma' as name, cast(30.25 as double) as price
+union all
+select 4 as id, 'delta' as name, cast(40.75 as double) as price
+"""
+
+
+class TestCrossWorkspace4PartWriteView:
+    """End-to-end cross-workspace WRITE via ``CREATE OR REPLACE VIEW``.
+
+    Regression test for #172. Before the fix, the view materialization
+    delegated to the default ``create_or_replace_view()`` macro, which built
+    the target relation via ``api.Relation.create(...)`` without forwarding
+    ``workspace_name``. The rendered DDL was a 3-part name and Fabric Livy
+    failed with ``Artifact not found: \\`<current_ws>\\`.\\`<other_lh>\\```.
+
+    Flow:
+      1. The model ``cross_ws_write_view`` is configured with
+         ``workspace_name=WS2``, ``database=WS2_LH``,
+         ``schema=cross_ws_write`` (auto-created by the prior write tests),
+         ``materialized=view``.
+      2. ``dbt run`` issues a 4-part
+         ``CREATE OR REPLACE VIEW \\`WS2\\`.\\`WS2_LH\\`.\\`cross_ws_write\\`.cross_ws_write_view AS SELECT …``
+         from WS1's Livy session.
+      3. Test verifies the view exists in WS2 by issuing a 4-part SELECT
+         and counting rows / summing the price column.
+      4. A second ``dbt run`` validates idempotency — ``CREATE OR REPLACE
+         VIEW`` re-materializes cleanly.
+      5. Cleanup is handled by the post-test workspace nuke.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def _skip_unless_schema_enabled(self, is_schema_enabled):
+        if not is_schema_enabled:
+            pytest.skip(
+                "Cross-workspace 4-part naming is only supported on schema-enabled "
+                "lakehouses (Fabric Livy limitation)."
+            )
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, ws2_workspace_name, ws2_lakehouse_name):
+        return {
+            "name": "cross_workspace_4part_write_view",
+            "vars": {
+                "ws2_workspace_name": ws2_workspace_name,
+                "ws2_lakehouse_name": ws2_lakehouse_name,
+                "ws2_write_schema": _WS2_WRITE_SCHEMA,
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cross_ws_write_view.sql": CROSS_WS_WRITE_VIEW_SQL,
+        }
+
+    def test_cross_workspace_view_renders_four_part(
+        self, project, ws2_workspace_name, ws2_lakehouse_name
+    ):
+        # Compile-only check that ``relation_name`` resolves to the 4-part
+        # form. Note: this matches ``this``/``create_from`` rendering, which
+        # was already workspace-aware before #172. The real regression
+        # signal is the runtime ``test_cross_workspace_view_executes`` below
+        # — without the fix the materialization-time DDL omits the
+        # workspace prefix and the ``dbt run`` fails outright.
+        compile_results = run_dbt(["compile", "--select", "cross_ws_write_view"])
+        assert len(compile_results) == 1
+        node = compile_results[0].node
+        rendered_target = node.relation_name or ""
+        assert f"`{ws2_workspace_name}`" in rendered_target, (
+            f"expected WS2 name in rendered relation, got: {rendered_target}"
+        )
+        assert f"`{ws2_lakehouse_name}`" in rendered_target, (
+            f"expected WS2 lakehouse in rendered relation, got: {rendered_target}"
+        )
+        assert f"`{_WS2_WRITE_SCHEMA}`" in rendered_target, (
+            f"expected WS2 write schema in rendered relation, got: {rendered_target}"
+        )
+
+    def test_cross_workspace_view_executes(
+        self,
+        project,
+        ws2_workspace_name,
+        ws2_lakehouse_name,
+    ):
+        # First run — adapter creates the cross_ws_write schema in WS2 (or
+        # finds it already created by the sibling write tests) and emits
+        # ``CREATE OR REPLACE VIEW `WS2`.`WS2_LH`.`cross_ws_write`.cross_ws_write_view``
+        # from WS1's Livy session. Without the #172 fix, the rendered DDL
+        # omits the workspace prefix and Fabric Livy returns
+        # ``Artifact not found: `<ws1_name>`.`WS2_LH``` — this assertion is
+        # the primary regression signal.
+        run_results = run_dbt(["run", "--select", "cross_ws_write_view"])
+        assert len(run_results) == 1, f"expected 1 run result, got {len(run_results)}"
+
+        # Verify the view now exists in WS2 by issuing a raw 4-part SELECT
+        # against WS1's Livy session. Fabric Livy resolves the SELECT
+        # through WS2's catalog.
+        sql = (
+            "select count(*) as n, sum(price) as total "
+            f"from `{ws2_workspace_name}`.`{ws2_lakehouse_name}`."
+            f"`{_WS2_WRITE_SCHEMA}`.cross_ws_write_view"
+        )
+        rows = project.run_sql(sql, fetch="all")
+        assert len(rows) == 1
+        n, total = rows[0]
+        assert int(n) == 4, f"expected 4 rows in WS2 cross-workspace view, got {n}"
+        assert abs(float(total) - (10.5 + 20.0 + 30.25 + 40.75)) < 1e-6, (
+            f"price sum mismatch in WS2 view: {total}"
+        )
+
+    def test_cross_workspace_view_is_idempotent(
+        self,
+        project,
+        ws2_workspace_name,
+        ws2_lakehouse_name,
+    ):
+        # Re-materialize. ``CREATE OR REPLACE VIEW`` re-executes cleanly
+        # against the existing 4-part relation in WS2.
+        run_results = run_dbt(["run", "--select", "cross_ws_write_view"])
+        assert len(run_results) == 1
+
+        sql = (
+            "select count(*) as n "
+            f"from `{ws2_workspace_name}`.`{ws2_lakehouse_name}`."
+            f"`{_WS2_WRITE_SCHEMA}`.cross_ws_write_view"
+        )
+        rows = project.run_sql(sql, fetch="all")
+        assert int(rows[0][0]) == 4, (
+            "expected the WS2 cross-workspace view to still resolve to 4 rows "
+            "after an idempotent re-run"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Positive: cross-workspace WRITE via SNAPSHOT materialization (issue #172)
+# ---------------------------------------------------------------------------
+
+
+# Source table in WS1 (the test write target's home lakehouse) that the
+# snapshot reads from via ``ref()``. We need a mutable source to exercise
+# both the snapshot CTAS (first run) and the MERGE-INTO path (subsequent
+# runs); the source is configured with ``materialized=table`` (no
+# ``workspace_name``) so it lives in WS1 alongside the test's main schema.
+#
+# The body is parameterised by a project var so we can rebuild the source
+# with mutated rows between snapshot runs without rewriting the model file.
+CROSS_WS_SNAPSHOT_SOURCE_SQL = """
+{{ config(materialized='table', file_format='delta') }}
+
+{% set bump = var('snap_source_bump', 0) %}
+
+select 1 as id, 'alpha' as name, cast(10.5 as double)  as price union all
+select 2 as id, 'beta'  as name, cast(20.0 as double)  as price union all
+select 3 as id, 'gamma' as name, cast(30.25 as double) as price union all
+select 4 as id, 'delta_v{{ bump }}' as name, cast(40.75 as double) as price
+"""
+
+
+# Snapshot defined in SQL (``{% snapshot %}`` block) — matches the
+# convention of the existing functional snapshot tests in this repo
+# (``tests/functional/adapter/basic/test_snapshot_timestamp.py``). Both the
+# SQL block form and the YAML form (used in the issue's repro repo) compile
+# to the same materialization, so this exercises the exact code path the
+# bug report covers.
+CROSS_WS_SNAPSHOT_SQL = """
+{% snapshot cross_ws_write_snapshot %}
+    {{ config(
+        strategy='check',
+        unique_key='id',
+        check_cols=['name'],
+        file_format='delta',
+        workspace_name=var('ws2_workspace_name'),
+        target_database=var('ws2_lakehouse_name'),
+        target_schema=var('ws2_write_schema')
+    ) }}
+    select * from {{ ref('cross_ws_snapshot_source') }}
+{% endsnapshot %}
+"""
+
+
+class TestCrossWorkspace4PartWriteSnapshot:
+    """End-to-end cross-workspace WRITE via the ``snapshot`` materialization.
+
+    Regression test for #172. The snapshot materialization built its target
+    relation through ``get_or_create_relation(...)`` which doesn't forward
+    ``workspace_name`` to the resulting relation; the staging view created by
+    ``spark_build_snapshot_staging_table`` also dropped the workspace. Both
+    paths emitted 3-part DDL against a 4-part target → ``Artifact not found``.
+
+    Flow:
+      1. A regular WS1 table ``cross_ws_snapshot_source`` is materialized
+         with 4 rows.
+      2. First ``dbt snapshot`` issues a cross-workspace CTAS to create the
+         SCD2 table in WS2 (the ``not target_relation_exists`` branch).
+         Validates that the target_relation now carries workspace and
+         renders 4-part.
+      3. The source is then mutated (one row's ``name`` is bumped) by
+         re-running the source model with a project-var override.
+      4. Second ``dbt snapshot`` exercises the MERGE INTO path: a staging
+         view is created in WS2 (the staging fix), and a MERGE INTO targets
+         the WS2 snapshot. SCD2 history grows by 1 row (5 rows total).
+      5. The mutated row's prior SCD2 record now has a non-null
+         ``dbt_valid_to``.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def _skip_unless_schema_enabled(self, is_schema_enabled):
+        if not is_schema_enabled:
+            pytest.skip(
+                "Cross-workspace 4-part naming is only supported on schema-enabled "
+                "lakehouses (Fabric Livy limitation)."
+            )
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, ws2_workspace_name, ws2_lakehouse_name):
+        return {
+            "name": "cross_workspace_4part_write_snapshot",
+            "vars": {
+                "ws2_workspace_name": ws2_workspace_name,
+                "ws2_lakehouse_name": ws2_lakehouse_name,
+                "ws2_write_schema": _WS2_WRITE_SCHEMA,
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cross_ws_snapshot_source.sql": CROSS_WS_SNAPSHOT_SOURCE_SQL,
+        }
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {
+            "cross_ws_write_snapshot.sql": CROSS_WS_SNAPSHOT_SQL,
+        }
+
+    def _count_rows(self, project, ws2_workspace_name, ws2_lakehouse_name) -> int:
+        sql = (
+            "select count(*) as n "
+            f"from `{ws2_workspace_name}`.`{ws2_lakehouse_name}`."
+            f"`{_WS2_WRITE_SCHEMA}`.cross_ws_write_snapshot"
+        )
+        rows = project.run_sql(sql, fetch="all")
+        return int(rows[0][0])
+
+    def test_snapshot_renders_four_part(self, project, ws2_workspace_name, ws2_lakehouse_name):
+        compile_results = run_dbt(["compile", "--select", "cross_ws_write_snapshot"])
+        # compile may return >1 result if upstream models are touched; find
+        # the snapshot node explicitly.
+        snapshot_results = [r for r in compile_results if r.node.name == "cross_ws_write_snapshot"]
+        assert len(snapshot_results) == 1, (
+            f"expected exactly 1 snapshot compile result, got {len(snapshot_results)}"
+        )
+        node = snapshot_results[0].node
+        rendered_target = node.relation_name or ""
+        assert f"`{ws2_workspace_name}`" in rendered_target, (
+            f"expected WS2 name in rendered relation, got: {rendered_target}"
+        )
+        assert f"`{ws2_lakehouse_name}`" in rendered_target, (
+            f"expected WS2 lakehouse in rendered relation, got: {rendered_target}"
+        )
+        assert f"`{_WS2_WRITE_SCHEMA}`" in rendered_target, (
+            f"expected WS2 write schema in rendered relation, got: {rendered_target}"
+        )
+
+    def test_snapshot_first_run_ctas_into_ws2(
+        self, project, ws2_workspace_name, ws2_lakehouse_name
+    ):
+        # Build the WS1 source table first (4 rows, name='delta_v0' for id=4).
+        run_results = run_dbt(["run", "--select", "cross_ws_snapshot_source"])
+        assert len(run_results) == 1
+
+        # First snapshot — target doesn't exist yet → CTAS path in
+        # snapshot.sql. Without the #172 fix the CTAS would render a
+        # 3-part name and fail with ``Artifact not found``.
+        snap_results = run_dbt(["snapshot", "--select", "cross_ws_write_snapshot"])
+        assert len(snap_results) == 1
+
+        n = self._count_rows(project, ws2_workspace_name, ws2_lakehouse_name)
+        assert n == 4, f"expected 4 rows after initial cross-workspace snapshot CTAS, got {n}"
+
+    def test_snapshot_second_run_merges_into_ws2(
+        self, project, ws2_workspace_name, ws2_lakehouse_name
+    ):
+        # Rebuild the source with id=4's name bumped from ``delta_v0`` to
+        # ``delta_v1``. Rerunning the source model is the simplest way to
+        # mutate the upstream input that the snapshot will detect.
+        run_results = run_dbt(
+            [
+                "run",
+                "--select",
+                "cross_ws_snapshot_source",
+                "--vars",
+                "{snap_source_bump: 1}",
+            ]
+        )
+        assert len(run_results) == 1
+
+        # Second snapshot — target exists → MERGE INTO path. This exercises
+        # both the workspace-qualified target_relation AND the staging
+        # tmp_relation (``spark_build_snapshot_staging_table``) which the fix
+        # also patches to carry workspace.
+        snap_results = run_dbt(["snapshot", "--select", "cross_ws_write_snapshot"])
+        assert len(snap_results) == 1
+
+        n = self._count_rows(project, ws2_workspace_name, ws2_lakehouse_name)
+        assert n == 5, (
+            "expected 5 SCD2 rows in WS2 after MERGE INTO "
+            f"(4 original incl. 1 closed-out + 1 new current), got {n}"
+        )
+
+        # Verify SCD2 semantics: exactly one historical row for id=4 has a
+        # non-null ``dbt_valid_to`` (the prior version), and one current
+        # row has ``dbt_valid_to is null``.
+        scd_sql = (
+            "select dbt_valid_to is null as is_current, count(*) as n "
+            f"from `{ws2_workspace_name}`.`{ws2_lakehouse_name}`."
+            f"`{_WS2_WRITE_SCHEMA}`.cross_ws_write_snapshot "
+            "where id = 4 group by dbt_valid_to is null"
+        )
+        scd_rows = {bool(r[0]): int(r[1]) for r in project.run_sql(scd_sql, fetch="all")}
+        assert scd_rows.get(True) == 1, (
+            f"expected exactly 1 current row for id=4 in WS2 snapshot, got {scd_rows}"
+        )
+        assert scd_rows.get(False) == 1, (
+            f"expected exactly 1 historical (closed-out) row for id=4 in WS2 snapshot, "
+            f"got {scd_rows}"
+        )

--- a/tests/functional/adapter/test_cross_workspace.py
+++ b/tests/functional/adapter/test_cross_workspace.py
@@ -574,12 +574,6 @@ class TestCrossWorkspace4PartWriteIncremental:
 # ---------------------------------------------------------------------------
 
 
-# A model whose physical view lives in WS2. Mirrors ``CROSS_WS_WRITE_TABLE_SQL``
-# but materialized as ``view``. Regression coverage for issue #172 where
-# ``workspace_name`` was not forwarded from the model config to
-# ``target_relation``, so the rendered DDL emitted only a 3-part name and
-# Fabric Livy returned ``Artifact not found`` because it tried to resolve the
-# lakehouse inside the *current* workspace.
 CROSS_WS_WRITE_VIEW_SQL = """
 {{ config(
     materialized='view',
@@ -599,29 +593,6 @@ select 4 as id, 'delta' as name, cast(40.75 as double) as price
 
 
 class TestCrossWorkspace4PartWriteView:
-    """End-to-end cross-workspace WRITE via ``CREATE OR REPLACE VIEW``.
-
-    Regression test for #172. Before the fix, the view materialization
-    delegated to the default ``create_or_replace_view()`` macro, which built
-    the target relation via ``api.Relation.create(...)`` without forwarding
-    ``workspace_name``. The rendered DDL was a 3-part name and Fabric Livy
-    failed with ``Artifact not found: \\`<current_ws>\\`.\\`<other_lh>\\```.
-
-    Flow:
-      1. The model ``cross_ws_write_view`` is configured with
-         ``workspace_name=WS2``, ``database=WS2_LH``,
-         ``schema=cross_ws_write`` (auto-created by the prior write tests),
-         ``materialized=view``.
-      2. ``dbt run`` issues a 4-part
-         ``CREATE OR REPLACE VIEW \\`WS2\\`.\\`WS2_LH\\`.\\`cross_ws_write\\`.cross_ws_write_view AS SELECT …``
-         from WS1's Livy session.
-      3. Test verifies the view exists in WS2 by issuing a 4-part SELECT
-         and counting rows / summing the price column.
-      4. A second ``dbt run`` validates idempotency — ``CREATE OR REPLACE
-         VIEW`` re-materializes cleanly.
-      5. Cleanup is handled by the post-test workspace nuke.
-    """
-
     @pytest.fixture(scope="class", autouse=True)
     def _skip_unless_schema_enabled(self, is_schema_enabled):
         if not is_schema_enabled:
@@ -650,12 +621,6 @@ class TestCrossWorkspace4PartWriteView:
     def test_cross_workspace_view_renders_four_part(
         self, project, ws2_workspace_name, ws2_lakehouse_name
     ):
-        # Compile-only check that ``relation_name`` resolves to the 4-part
-        # form. Note: this matches ``this``/``create_from`` rendering, which
-        # was already workspace-aware before #172. The real regression
-        # signal is the runtime ``test_cross_workspace_view_executes`` below
-        # — without the fix the materialization-time DDL omits the
-        # workspace prefix and the ``dbt run`` fails outright.
         compile_results = run_dbt(["compile", "--select", "cross_ws_write_view"])
         assert len(compile_results) == 1
         node = compile_results[0].node
@@ -676,19 +641,9 @@ class TestCrossWorkspace4PartWriteView:
         ws2_workspace_name,
         ws2_lakehouse_name,
     ):
-        # First run — adapter creates the cross_ws_write schema in WS2 (or
-        # finds it already created by the sibling write tests) and emits
-        # ``CREATE OR REPLACE VIEW `WS2`.`WS2_LH`.`cross_ws_write`.cross_ws_write_view``
-        # from WS1's Livy session. Without the #172 fix, the rendered DDL
-        # omits the workspace prefix and Fabric Livy returns
-        # ``Artifact not found: `<ws1_name>`.`WS2_LH``` — this assertion is
-        # the primary regression signal.
         run_results = run_dbt(["run", "--select", "cross_ws_write_view"])
         assert len(run_results) == 1, f"expected 1 run result, got {len(run_results)}"
 
-        # Verify the view now exists in WS2 by issuing a raw 4-part SELECT
-        # against WS1's Livy session. Fabric Livy resolves the SELECT
-        # through WS2's catalog.
         sql = (
             "select count(*) as n, sum(price) as total "
             f"from `{ws2_workspace_name}`.`{ws2_lakehouse_name}`."
@@ -708,8 +663,6 @@ class TestCrossWorkspace4PartWriteView:
         ws2_workspace_name,
         ws2_lakehouse_name,
     ):
-        # Re-materialize. ``CREATE OR REPLACE VIEW`` re-executes cleanly
-        # against the existing 4-part relation in WS2.
         run_results = run_dbt(["run", "--select", "cross_ws_write_view"])
         assert len(run_results) == 1
 
@@ -730,14 +683,6 @@ class TestCrossWorkspace4PartWriteView:
 # ---------------------------------------------------------------------------
 
 
-# Source table in WS1 (the test write target's home lakehouse) that the
-# snapshot reads from via ``ref()``. We need a mutable source to exercise
-# both the snapshot CTAS (first run) and the MERGE-INTO path (subsequent
-# runs); the source is configured with ``materialized=table`` (no
-# ``workspace_name``) so it lives in WS1 alongside the test's main schema.
-#
-# The body is parameterised by a project var so we can rebuild the source
-# with mutated rows between snapshot runs without rewriting the model file.
 CROSS_WS_SNAPSHOT_SOURCE_SQL = """
 {{ config(materialized='table', file_format='delta') }}
 
@@ -750,12 +695,6 @@ select 4 as id, 'delta_v{{ bump }}' as name, cast(40.75 as double) as price
 """
 
 
-# Snapshot defined in SQL (``{% snapshot %}`` block) — matches the
-# convention of the existing functional snapshot tests in this repo
-# (``tests/functional/adapter/basic/test_snapshot_timestamp.py``). Both the
-# SQL block form and the YAML form (used in the issue's repro repo) compile
-# to the same materialization, so this exercises the exact code path the
-# bug report covers.
 CROSS_WS_SNAPSHOT_SQL = """
 {% snapshot cross_ws_write_snapshot %}
     {{ config(
@@ -773,30 +712,6 @@ CROSS_WS_SNAPSHOT_SQL = """
 
 
 class TestCrossWorkspace4PartWriteSnapshot:
-    """End-to-end cross-workspace WRITE via the ``snapshot`` materialization.
-
-    Regression test for #172. The snapshot materialization built its target
-    relation through ``get_or_create_relation(...)`` which doesn't forward
-    ``workspace_name`` to the resulting relation; the staging view created by
-    ``spark_build_snapshot_staging_table`` also dropped the workspace. Both
-    paths emitted 3-part DDL against a 4-part target → ``Artifact not found``.
-
-    Flow:
-      1. A regular WS1 table ``cross_ws_snapshot_source`` is materialized
-         with 4 rows.
-      2. First ``dbt snapshot`` issues a cross-workspace CTAS to create the
-         SCD2 table in WS2 (the ``not target_relation_exists`` branch).
-         Validates that the target_relation now carries workspace and
-         renders 4-part.
-      3. The source is then mutated (one row's ``name`` is bumped) by
-         re-running the source model with a project-var override.
-      4. Second ``dbt snapshot`` exercises the MERGE INTO path: a staging
-         view is created in WS2 (the staging fix), and a MERGE INTO targets
-         the WS2 snapshot. SCD2 history grows by 1 row (5 rows total).
-      5. The mutated row's prior SCD2 record now has a non-null
-         ``dbt_valid_to``.
-    """
-
     @pytest.fixture(scope="class", autouse=True)
     def _skip_unless_schema_enabled(self, is_schema_enabled):
         if not is_schema_enabled:
@@ -839,8 +754,6 @@ class TestCrossWorkspace4PartWriteSnapshot:
 
     def test_snapshot_renders_four_part(self, project, ws2_workspace_name, ws2_lakehouse_name):
         compile_results = run_dbt(["compile", "--select", "cross_ws_write_snapshot"])
-        # compile may return >1 result if upstream models are touched; find
-        # the snapshot node explicitly.
         snapshot_results = [r for r in compile_results if r.node.name == "cross_ws_write_snapshot"]
         assert len(snapshot_results) == 1, (
             f"expected exactly 1 snapshot compile result, got {len(snapshot_results)}"
@@ -860,13 +773,9 @@ class TestCrossWorkspace4PartWriteSnapshot:
     def test_snapshot_first_run_ctas_into_ws2(
         self, project, ws2_workspace_name, ws2_lakehouse_name
     ):
-        # Build the WS1 source table first (4 rows, name='delta_v0' for id=4).
         run_results = run_dbt(["run", "--select", "cross_ws_snapshot_source"])
         assert len(run_results) == 1
 
-        # First snapshot — target doesn't exist yet → CTAS path in
-        # snapshot.sql. Without the #172 fix the CTAS would render a
-        # 3-part name and fail with ``Artifact not found``.
         snap_results = run_dbt(["snapshot", "--select", "cross_ws_write_snapshot"])
         assert len(snap_results) == 1
 
@@ -876,9 +785,6 @@ class TestCrossWorkspace4PartWriteSnapshot:
     def test_snapshot_second_run_merges_into_ws2(
         self, project, ws2_workspace_name, ws2_lakehouse_name
     ):
-        # Rebuild the source with id=4's name bumped from ``delta_v0`` to
-        # ``delta_v1``. Rerunning the source model is the simplest way to
-        # mutate the upstream input that the snapshot will detect.
         run_results = run_dbt(
             [
                 "run",
@@ -890,10 +796,6 @@ class TestCrossWorkspace4PartWriteSnapshot:
         )
         assert len(run_results) == 1
 
-        # Second snapshot — target exists → MERGE INTO path. This exercises
-        # both the workspace-qualified target_relation AND the staging
-        # tmp_relation (``spark_build_snapshot_staging_table``) which the fix
-        # also patches to carry workspace.
         snap_results = run_dbt(["snapshot", "--select", "cross_ws_write_snapshot"])
         assert len(snap_results) == 1
 
@@ -903,9 +805,6 @@ class TestCrossWorkspace4PartWriteSnapshot:
             f"(4 original incl. 1 closed-out + 1 new current), got {n}"
         )
 
-        # Verify SCD2 semantics: exactly one historical row for id=4 has a
-        # non-null ``dbt_valid_to`` (the prior version), and one current
-        # row has ``dbt_valid_to is null``.
         scd_sql = (
             "select dbt_valid_to is null as is_current, count(*) as n "
             f"from `{ws2_workspace_name}`.`{ws2_lakehouse_name}`."


### PR DESCRIPTION
## Summary

Fixes #172.

The cross-workspace 4-part naming feature (introduced in #167/#168) forwards
`workspace_name` from a model's `config()` onto `target_relation` for **table**
and **incremental** materializations only. **View**, **snapshot**, and
**materialized_lake_view** materializations built their target relation via
paths that drop the workspace, emitting 3-part DDL against a 4-part target:

```
create or replace view `OtherLakehouse`.`dbt`.test_model as ...
--> Database Error: Artifact not found: `MainWorkspace`.`OtherLakehouse`
```

## Manual reproduction (issue scenario)

Verified on a live Fabric tenant with two schema-enabled lakehouses (one in
WS1, one in WS2). Repro project mirrors @cheyney-w's
[`dbt-fabricspark-cross-workspace-demo`](https://github.com/cheyney-w/dbt-fabricspark-cross-workspace-demo)
models:

**Before the fix:**

```
1 of 1 START sql view model dbt Fabric Spark 2.<WS2_LH>.repro.view_in_other  [RUN]
1 of 1 ERROR creating sql view model dbt Fabric Spark 2.<WS2_LH>.repro.view_in_other  [ERROR]
  Runtime Error: Artifact not found: `dbt Fabric Spark 1`.`<WS2_LH>`
```

Same error for `dbt snapshot` against the same cross-workspace target.

**After the fix:**

```
1 of 1 OK created sql view model dbt Fabric Spark 2.<WS2_LH>.repro.view_in_other  [OK in 2.12s]
1 of 1 OK snapshotted dbt Fabric Spark 2.<WS2_LH>.repro.snap_in_other  [OK in 9.30s]
```

Rendered DDL is now correct:

```
create or replace view `dbt Fabric Spark 2`.`<WS2_LH>`.`repro`.view_in_other as ...
merge into `dbt Fabric Spark 2`.`<WS2_LH>`.`repro`.snap_in_other as DBT_INTERNAL_DEST
  using `dbt Fabric Spark 2`.`<WS2_LH>`.`repro`.snap_in_other__dbt_tmp as DBT_INTERNAL_SOURCE
  on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id ...
```

Note that the snapshot staging view (`__dbt_tmp`) is also workspace-qualified
now — this is the second snapshot.sql change.

## Root causes

| Materialization | How target_relation was built | Why workspace was lost |
|---|---|---|
| `view` | Default global `create_or_replace_view()` | `api.Relation.create(identifier, schema, database, type='view')` — no workspace kwarg |
| `snapshot` | `get_or_create_relation(...)` | Default dispatch: cache hit returns un-workspaced relation; fallback `api.Relation.create(...)` also drops workspace |
| `snapshot` staging view | `spark_build_snapshot_staging_table` | `api.Relation.create(... type='view')` copied schema+database from target but not workspace |
| `materialized_lake_view` | `api.Relation.create(... type='materialized_view')` | Same pattern as view |

The `table` and `incremental` materializations avoid the bug because they
either pass `workspace=config.get('workspace_name')` explicitly (table.sql) or
use `this`, which is built via `FabricSparkRelation.create_from` and auto-pulls
`workspace_name`.

## Fix

* **`mv.sql`** — full fabricspark view materialization mirroring `table.sql`:
  builds `target_relation` with `workspace=config.get('workspace_name')`.
  Preserves the existing `fabricspark__handle_existing_table` cleanup for
  stale tables.
* **`snapshot.sql`** — re-incorporates workspace onto `target_relation` after
  `get_or_create_relation` (uses `incorporate(workspace=workspace_name)`,
  which round-trips through `FabricSparkRelation.from_dict` and preserves the
  field). Staging `tmp_relation` also forwards `target_relation.workspace`
  so MERGE INTO sees a 4-part staging view.
* **`materialized_lake_view.sql`** — adds `workspace=workspace_name` to the
  `target_relation` build. (The MLV REST API lakehouse-id resolution still
  uses the profile workspace; cross-workspace MLV via REST is a separate
  concern and is **not** in this PR's scope.)

## Tests

Adds two functional test classes to `tests/functional/adapter/test_cross_workspace.py`:

* **`TestCrossWorkspace4PartWriteView`** — compile + first-run + idempotent
  re-run, with runtime 4-part SELECT verification against WS2. Primary
  regression signal is `test_cross_workspace_view_executes` which fails
  outright on the un-fixed code path.
* **`TestCrossWorkspace4PartWriteSnapshot`** — exercises both the CTAS path
  (first run) and the MERGE INTO path (mutated source between runs). Asserts
  SCD2 history (4 → 5 rows with `dbt_valid_to` populated on the closed-out
  row). The MERGE-into-WS2 path validates the staging-view workspace fix.

Both classes skip in `no_schema` mode (Fabric Livy 4-part naming is
schema-enabled-only). Reuses the existing `cross_ws_write` schema in WS2.

## Validation

Run against a live Fabric tenant on this branch (WS1 + WS2 both
schema-enabled):

| Target | Result |
|---|---|
| `npx nx run dbt-fabricspark:lint` | ✅ |
| `npx nx run dbt-fabricspark:build` | ✅ |
| `npx nx run dbt-fabricspark:test:unit` | ✅ 216 passed, 11 skipped |
| `pytest tests/functional/adapter/test_cross_workspace.py` (all 17 tests) | ✅ |
| `pytest tests/functional/adapter/basic/test_snapshot_*` (regression) | ✅ |
| `pytest tests/functional/adapter/basic/test_base.py` (view regression) | ✅ |
| `npx nx run dbt-fabricspark:test:local-e2e` | ✅ |

## Out of scope

* Cross-workspace MLV REST API — the MLV materialization here is fixed at
  the relation-rendering layer for parity, but the MLV REST API path resolves
  lakehouse IDs against the profile workspace. Cross-workspace MLV via REST
  is a larger change and is intentionally not addressed here.
* Workspace-aware `adapter.get_relation` — the existing cross-workspace
  incremental MERGE INTO tests already prove the cache flow works
  cross-workspace, so no Python-side change is needed for snapshot
  existence detection.

Closes #172.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>