### PR TITLE
fix: stop suppressing exceptions in six `__exit__` methods

### DIFF
--- a/src/dbt/adapters/fabricspark/concurrent_livy.py
+++ b/src/dbt/adapters/fabricspark/concurrent_livy.py
@@ -122,7 +122,7 @@ class HighConcurrencySession:
         exc_val: Exception | None,
         exc_tb: TracebackType | None,
     ) -> bool:
-        return True
+        return False
 
     # ---- acquire ---------------------------------------------------------
 
@@ -344,7 +344,7 @@ class HighConcurrencyCursor:
         exc_tb: TracebackType | None,
     ) -> bool:
         self.close()
-        return True
+        return False
 
     @property
     def description(
@@ -631,7 +631,7 @@ class HighConcurrencyConnection:
         exc_tb: TracebackType | None,
     ) -> bool:
         self.close()
-        return True
+        return False
 
 
 def _maybe_create_shortcuts(credentials: FabricSparkCredentials) -> None:

--- a/src/dbt/adapters/fabricspark/singleton_livy.py
+++ b/src/dbt/adapters/fabricspark/singleton_livy.py
@@ -52,7 +52,7 @@ class LivySession:
         exc_val: Exception | None,
         exc_tb: TracebackType | None,
     ) -> bool:
-        return True
+        return False
 
     def try_reuse_session(self, session_id: str) -> bool:
         """Try to reuse an existing session by ID.
@@ -382,7 +382,7 @@ class LivyCursor:
         exc_tb: TracebackType | None,
     ) -> bool:
         self.close()
-        return True
+        return False
 
     @property
     def description(
@@ -710,7 +710,7 @@ class LivyConnection:
         exc_tb: TracebackType | None,
     ) -> bool:
         self.close()
-        return True
+        return False
 
 
 def _atexit_cleanup() -> None:


### PR DESCRIPTION
# Why this change is needed

Filed as #191.

All six `__exit__` methods in `singleton_livy.py` and `concurrent_livy.py` end with `return True`. In Python, returning a truthy value from `__exit__` suppresses any exception raised inside the `with` block — so every database error, timeout, `KeyboardInterrupt`, and programming bug raised through one of these context managers is silently swallowed.

User impact (also in #191):

- A dbt run can report success while a model that ran inside one of these context managers actually failed.
- `KeyboardInterrupt` is suppressed — `Ctrl+C` may not actually stop a long-running command.
- Programming bugs raised during cleanup are hidden, making them effectively impossible to diagnose from the dbt log.

# How

Change `return True` to `return False` in all six `__exit__` methods. Cleanup logic in the method bodies (e.g. `self.close()`) is unchanged — only the `return` value differs. Any exception raised inside the corresponding `with` block now propagates as Python normally does.

Affected methods:

- `singleton_livy.py`: `LivySession.__exit__`, `LivyCursor.__exit__`, `LivyConnection.__exit__`
- `concurrent_livy.py`: `HighConcurrencySession.__exit__`, `HighConcurrencyCursor.__exit__`, `HighConcurrencyConnection.__exit__`

# Test

I'm a non-Microsoft contributor and cannot run the CI against the Microsoft Fabric tenant. Happy to add a local test-run screenshot if a maintainer wants to engage with the change — please confirm whether you'd prefer that or a unit-test-only approach (e.g. a test that asserts `__exit__` returns `False` so this can't silently regress).

Closes #191

