### PR TITLE
fix: stop forcing botocore/boto3 loggers to DEBUG at import time

### DIFF
--- a/src/dbt/adapters/fabricspark/connections.py
+++ b/src/dbt/adapters/fabricspark/connections.py
@@ -42,8 +42,6 @@ from dbt.adapters.sql import SQLConnectionManager
 logger = AdapterLogger("Microsoft Fabric-Spark")
 for logger_name in [
     "fabricspark.connector",
-    "botocore",
-    "boto3",
     "Microsoft Fabric-Spark.connector",
 ]:
     logger.debug(f"Setting {logger_name} to DEBUG")


### PR DESCRIPTION
> [!NOTE]
> Closes #197.

# Why this change is needed

`src/dbt/adapters/fabricspark/connections.py` iterates a list of logger names at module import time and forces each one to DEBUG via `AdapterLogger.set_adapter_dependency_log_level`:

```python
logger = AdapterLogger("Microsoft Fabric-Spark")
for logger_name in [
    "fabricspark.connector",
    "botocore",
    "boto3",
    "Microsoft Fabric-Spark.connector",
]:
    logger.debug(f"Setting {logger_name} to DEBUG")
    logger.set_adapter_dependency_log_level(logger_name, "DEBUG")
```

The adapter has no AWS dependency — `boto3` / `botocore` are not in [`pyproject.toml`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/pyproject.toml). They look like a leftover from a `dbt-spark` / Databricks ancestor that survived a refactor of this block (the previous direct `logging.getLogger(...).setLevel(...)` calls were replaced with the loop-based `AdapterLogger` API, but the AWS entries were not pruned).

**User impact:** the two AWS entries are no-ops *until* the user's project transitively imports `boto3` — common in dbt projects with S3-backed assets, or in environments where other packages on the path pull AWS SDKs in. When that happens, this code path silently turns on `boto3` DEBUG-level logging across the entire process, and every subsequent `boto3` call dumps debug noise (request signing, response bodies, retry traces) into the dbt log regardless of dbt's own log level. The user did not configure boto3 debug logging anywhere in their project, but now it's on.

# How

Remove `"botocore"` and `"boto3"` from the loop. This adapter has no business configuring loggers for libraries it does not depend on. If a user wants verbose AWS logs they will set their own log level.

# Test

This change drops two no-op string entries from a list literal; the loop body is unchanged. No functional behavior of the adapter is touched, so no new test is added. Local `npx nx run dbt-fabricspark:test` is not feasible from outside the `@microsoft.com` Fabric tenant — see the contributor screenshot exemption in the PR template; happy to revisit if a reviewer wants a unit test asserting that the dependency loggers list no longer contains AWS entries.
