### PR TITLE
refactor: extract `parse_retry_after` to shared helper and drop `datetime.utcnow()`

### DIFF
--- a/src/dbt/adapters/fabricspark/_http_utils.py
+++ b/src/dbt/adapters/fabricspark/_http_utils.py
@@ -1,0 +1,35 @@
+"""Shared HTTP helpers for Fabric REST clients."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import requests
+
+
+def parse_retry_after(response: requests.Response) -> float:
+    """Extract wait time (seconds) from a 429 response.
+
+    Checks the ``Retry-After`` header first, then falls back to the
+    Fabric-specific ``until: <timestamp>`` pattern in the response body
+    (e.g. ``"...until: 4/17/2026 12:22:35 PM (UTC)"``). Returns 0 if no
+    hint is found.
+    """
+    header = response.headers.get("Retry-After", "")
+    if header:
+        try:
+            return float(header)
+        except ValueError:
+            pass
+    try:
+        body = response.json()
+        msg = body.get("message", "")
+        if "until:" in msg:
+            ts_str = msg.split("until:")[1].strip().rstrip(")")
+            ts_str = ts_str.replace("(UTC", "").strip()
+            target = datetime.strptime(ts_str, "%m/%d/%Y %I:%M:%S %p").replace(tzinfo=timezone.utc)
+            delta = (target - datetime.now(timezone.utc)).total_seconds()
+            return max(delta, 0)
+    except Exception:
+        pass
+    return 0

--- a/src/dbt/adapters/fabricspark/concurrent_livy.py
+++ b/src/dbt/adapters/fabricspark/concurrent_livy.py
@@ -18,6 +18,7 @@ from dbt_common.utils.encoding import DECIMALS
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.exceptions import FailedToConnectError
 from dbt.adapters.fabricspark import livysession as _livy_helpers
+from dbt.adapters.fabricspark._http_utils import parse_retry_after
 from dbt.adapters.fabricspark.credentials import FabricSparkCredentials
 from dbt.adapters.fabricspark.livy_backend import LivyBackend
 from dbt.adapters.fabricspark.shortcuts import ShortcutClient
@@ -55,10 +56,6 @@ _shortcuts_done: "set[tuple[str, str]]" = set()
 
 def _get_headers(credentials: FabricSparkCredentials, tokenPrint: bool = False) -> dict[str, str]:
     return _livy_helpers.get_headers(credentials, tokenPrint)
-
-
-def _parse_retry_after(response: requests.Response) -> float:
-    return _livy_helpers._parse_retry_after(response)
 
 
 def derive_session_tag(credentials: FabricSparkCredentials) -> str:
@@ -415,7 +412,7 @@ class HighConcurrencyCursor:
                 time.sleep(wait)
                 continue
             if res.status_code == 429:
-                retry_after = _parse_retry_after(res)
+                retry_after = parse_retry_after(res)
                 wait = max(retry_after, 2**attempt)
                 logger.debug(f"HC statement submit got HTTP 429, retrying in {wait:.0f}s")
                 time.sleep(wait)
@@ -494,7 +491,7 @@ class HighConcurrencyCursor:
                 continue
             if resp.status_code == 429:
                 consecutive_failures += 1
-                retry_after = _parse_retry_after(resp)
+                retry_after = parse_retry_after(resp)
                 wait = max(retry_after, 2 ** (consecutive_failures - 1))
                 logger.debug(f"HC statement poll got HTTP 429, retrying in {wait:.0f}s")
                 time.sleep(wait)

--- a/src/dbt/adapters/fabricspark/livysession.py
+++ b/src/dbt/adapters/fabricspark/livysession.py
@@ -15,6 +15,7 @@ from azure.identity import AzureCliCredential, ClientSecretCredential
 from dbt_common.exceptions import DbtRuntimeError
 
 from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.fabricspark._http_utils import parse_retry_after
 from dbt.adapters.fabricspark.credentials import FabricSparkCredentials
 
 logger = AdapterLogger("Microsoft Fabric-Spark")
@@ -367,33 +368,6 @@ def get_headers(credentials: FabricSparkCredentials, tokenPrint: bool = False) -
     return headers
 
 
-def _parse_retry_after(response: requests.Response) -> float:
-    """Extract wait time from Retry-After header or 429 response body.
-
-    Falls back to 0 if no hint is found.
-    """
-    header = response.headers.get("Retry-After", "")
-    if header:
-        try:
-            return float(header)
-        except ValueError:
-            pass
-    # Fabric 429 body sometimes includes a retry-after timestamp in the message
-    try:
-        body = response.json()
-        msg = body.get("message", "")
-        # Fabric 429 body includes a timestamp like "...until: 4/17/2026 12:22:35 PM (UTC)"
-        if "until:" in msg:
-            ts_str = msg.split("until:")[1].strip().rstrip(")")
-            ts_str = ts_str.replace("(UTC", "").strip()
-            target = dt.datetime.strptime(ts_str, "%m/%d/%Y %I:%M:%S %p")
-            delta = (target - dt.datetime.utcnow()).total_seconds()
-            return max(delta, 0)
-    except Exception:
-        pass
-    return 0
-
-
 def get_lakehouse_properties(credentials: FabricSparkCredentials) -> dict:
     """Fetch lakehouse properties from the Fabric REST API.
 
@@ -424,7 +398,7 @@ def get_lakehouse_properties(credentials: FabricSparkCredentials) -> dict:
         try:
             response = requests.get(url, headers=headers, timeout=30)
             if response.status_code == 429:
-                retry_after = _parse_retry_after(response)
+                retry_after = parse_retry_after(response)
                 wait = max(retry_after, 2**attempt * 2)  # at least 2, 4, 8, 16, 32s
                 logger.debug(
                     f"Lakehouse properties API returned 429, "

--- a/src/dbt/adapters/fabricspark/mlv_api.py
+++ b/src/dbt/adapters/fabricspark/mlv_api.py
@@ -10,7 +10,6 @@ https://learn.microsoft.com/en-us/fabric/data-engineering/materialized-lake-view
 
 from __future__ import annotations
 
-import datetime as dt
 import random
 import time
 from typing import Any, Dict, List, Optional
@@ -19,6 +18,7 @@ import requests
 from dbt_common.exceptions import DbtRuntimeError
 
 from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.fabricspark._http_utils import parse_retry_after
 from dbt.adapters.fabricspark.credentials import FabricSparkCredentials
 from dbt.adapters.fabricspark.livysession import get_headers
 
@@ -138,33 +138,6 @@ def _extract_error_detail(response: requests.Response) -> str:
         return response.text or f"HTTP {response.status_code}"
 
 
-def _parse_retry_after(response: requests.Response) -> float:
-    """Extract wait time (seconds) from a 429 response.
-
-    Checks the ``Retry-After`` header first, then falls back to the
-    Fabric-specific "until: <timestamp>" pattern in the response body.
-    Returns 0 if no hint is found.
-    """
-    header = response.headers.get("Retry-After", "")
-    if header:
-        try:
-            return float(header)
-        except ValueError:
-            pass
-    try:
-        body = response.json()
-        msg = body.get("message", "")
-        if "until:" in msg:
-            ts_str = msg.split("until:")[1].strip().rstrip(")")
-            ts_str = ts_str.replace("(UTC", "").strip()
-            target = dt.datetime.strptime(ts_str, "%m/%d/%Y %I:%M:%S %p")
-            delta = (target - dt.datetime.utcnow()).total_seconds()
-            return max(delta, 0)
-    except Exception:
-        pass
-    return 0
-
-
 def _request_with_retry(
     method: str,
     url: str,
@@ -199,7 +172,7 @@ def _request_with_retry(
             if response.status_code in RETRYABLE_STATUS_CODES and attempt < max_retries:
                 detail = _extract_error_detail(response)
                 if response.status_code == 429:
-                    retry_after = _parse_retry_after(response)
+                    retry_after = parse_retry_after(response)
                     wait = max(retry_after, RETRY_BACKOFF_BASE**attempt) + random.uniform(0, 2)
                 else:
                     wait = RETRY_BACKOFF_BASE**attempt

--- a/src/dbt/adapters/fabricspark/singleton_livy.py
+++ b/src/dbt/adapters/fabricspark/singleton_livy.py
@@ -17,6 +17,7 @@ from requests.models import Response
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.exceptions import FailedToConnectError
 from dbt.adapters.fabricspark import livysession as _livy_helpers
+from dbt.adapters.fabricspark._http_utils import parse_retry_after
 from dbt.adapters.fabricspark.credentials import FabricSparkCredentials
 from dbt.adapters.fabricspark.livy_backend import LivyBackend
 from dbt.adapters.fabricspark.shortcuts import ShortcutClient
@@ -29,10 +30,6 @@ _session_lock = threading.Lock()
 
 def _get_headers(credentials: FabricSparkCredentials, tokenPrint: bool = False) -> dict[str, str]:
     return _livy_helpers.get_headers(credentials, tokenPrint)
-
-
-def _parse_retry_after(response: requests.Response) -> float:
-    return _livy_helpers._parse_retry_after(response)
 
 
 class LivySession:
@@ -448,7 +445,7 @@ class LivyCursor:
                 time.sleep(wait_time)
                 continue
             if res.status_code == 429:
-                retry_after = _parse_retry_after(res)
+                retry_after = parse_retry_after(res)
                 wait_time = max(retry_after, 2**attempt * 1)
                 logger.debug(
                     f"Livy statement submit got HTTP 429, "
@@ -540,7 +537,7 @@ class LivyCursor:
                 continue
             if poll_res.status_code == 429:
                 consecutive_failures += 1
-                retry_after = _parse_retry_after(poll_res)
+                retry_after = parse_retry_after(poll_res)
                 wait_time = max(retry_after, 2 ** (consecutive_failures - 1) * 1)
                 logger.debug(
                     f"Livy statement poll got HTTP 429, "

--- a/tests/unit/test_http_utils.py
+++ b/tests/unit/test_http_utils.py
@@ -1,0 +1,60 @@
+"""Unit tests for the shared HTTP helpers."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from dbt.adapters.fabricspark._http_utils import parse_retry_after
+
+
+def _response(headers=None, body=None):
+    resp = MagicMock()
+    resp.headers = headers or {}
+    if body is None:
+        resp.json.side_effect = ValueError("no body")
+    else:
+        resp.json.return_value = body
+    return resp
+
+
+def test_returns_numeric_retry_after_header():
+    assert parse_retry_after(_response(headers={"Retry-After": "7"})) == 7.0
+
+
+def test_returns_zero_when_header_and_body_missing():
+    assert parse_retry_after(_response()) == 0
+
+
+def test_falls_back_to_body_until_timestamp_when_header_missing():
+    target = (datetime.now(timezone.utc) + timedelta(seconds=12)).strftime("%m/%d/%Y %I:%M:%S %p")
+    body = {"message": f"Too many requests; retry until: {target} (UTC)"}
+    delta = parse_retry_after(_response(body=body))
+    # Allow small clock drift between strftime and the function's own datetime.now() call.
+    assert 10 <= delta <= 12
+
+
+def test_clamps_negative_delta_to_zero_when_until_is_in_past():
+    target = (datetime.now(timezone.utc) - timedelta(seconds=30)).strftime("%m/%d/%Y %I:%M:%S %p")
+    body = {"message": f"Too many requests; retry until: {target} (UTC)"}
+    assert parse_retry_after(_response(body=body)) == 0
+
+
+def test_falls_back_to_body_when_header_is_not_numeric():
+    target = (datetime.now(timezone.utc) + timedelta(seconds=5)).strftime("%m/%d/%Y %I:%M:%S %p")
+    body = {"message": f"Too many requests; retry until: {target} (UTC)"}
+    resp = _response(headers={"Retry-After": "not-a-number"}, body=body)
+    delta = parse_retry_after(resp)
+    assert 3 <= delta <= 5
+
+
+def test_returns_zero_when_body_is_not_json():
+    assert parse_retry_after(_response()) == 0
+
+
+def test_returns_zero_when_until_pattern_is_malformed():
+    body = {"message": "Too many requests; retry until: not-a-timestamp"}
+    assert parse_retry_after(_response(body=body)) == 0
+
+
+def test_returns_zero_when_message_has_no_until_clause():
+    body = {"message": "Too many requests"}
+    assert parse_retry_after(_response(body=body)) == 0


### PR DESCRIPTION
## Summary

Fixes #196.

`_parse_retry_after` exists as two independent full implementations (in `livysession.py` and `mlv_api.py`) plus two thin wrappers (in `singleton_livy.py` and `concurrent_livy.py`) that re-export the `livysession.py` copy through its underscore-prefixed name. Both full copies use `datetime.utcnow()`, deprecated since Python 3.12.

This PR consolidates the four locations into a single helper.

## Changes

- New module `src/dbt/adapters/fabricspark/_http_utils.py` exposing `parse_retry_after(response)`. Replaces `datetime.utcnow()` with `datetime.now(timezone.utc)` and parses the Fabric `until: ... (UTC)` timestamp as timezone-aware so the subtraction stays valid in a tz-aware world.
- `livysession.py` and `mlv_api.py`: drop their local `_parse_retry_after` definitions, import `parse_retry_after` from `_http_utils`. `mlv_api.py` no longer needs `import datetime as dt` (it had no other use).
- `singleton_livy.py` and `concurrent_livy.py`: drop the `_parse_retry_after` thin wrappers, import `parse_retry_after` from `_http_utils`, and call it directly at the existing retry sites.

The function is renamed from `_parse_retry_after` to `parse_retry_after` because it now lives in a private module (`_http_utils`) and is the module's only public symbol; the per-file leading underscore was about file-scope privacy, which the new module replaces with module-scope privacy.

## Diff shape

```
 src/dbt/adapters/fabricspark/_http_utils.py     | 35 +++++++++++++++  (new)
 src/dbt/adapters/fabricspark/concurrent_livy.py |  9 ++--
 src/dbt/adapters/fabricspark/livysession.py     | 30 +------------
 src/dbt/adapters/fabricspark/mlv_api.py         | 31 +------------
 src/dbt/adapters/fabricspark/singleton_livy.py  |  9 ++--
 tests/unit/test_http_utils.py                   | 60 +++++++++++++++++++++++++  (new)
```

## Test plan

- [x] New unit tests in `tests/unit/test_http_utils.py` cover:
  - Numeric `Retry-After` header
  - Missing header + missing body → 0
  - `until: <timestamp>` body fallback (future timestamp)
  - `until:` timestamp in the past → clamped to 0
  - Non-numeric header → falls back to body
  - Non-JSON body / malformed `until:` clause / no `until:` clause → 0
- [x] `tests/unit/test_livysession.py`, `tests/unit/test_mlv_api.py`, `tests/unit/test_concurrent_livy.py` still pass (the one pre-existing failure on `main`, `test_mlv_api.py::TestPollJobInstanceUntilComplete::test_raises_on_timeout`, is unrelated to this change).
- [x] `uv run ruff format --check .` clean.
- [x] `uv run ruff check .` clean.

Reviewers: happy to weigh in on the new module location / name, and to fold it into an existing module instead if preferred.

