### PR TITLE
chore: remove dead Thrift exception handler in `connections.py`

### DIFF
--- a/src/dbt/adapters/fabricspark/connections.py
+++ b/src/dbt/adapters/fabricspark/connections.py
@@ -109,12 +109,7 @@ class FabricSparkConnectionManager(SQLConnectionManager):
             if len(exc.args) == 0:
                 raise
 
-            thrift_resp = exc.args[0]
-            if hasattr(thrift_resp, "status"):
-                msg = thrift_resp.status.errorMessage
-                raise DbtRuntimeError(msg)
-            else:
-                raise DbtRuntimeError(str(exc))
+            raise DbtRuntimeError(str(exc))
 
     def cancel(self, connection: Connection) -> None:
         connection.handle.cancel()


### PR DESCRIPTION
## Summary

Fixes #202.

`FabricSparkConnectionManager.exception_handler` in [`src/dbt/adapters/fabricspark/connections.py`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/src/dbt/adapters/fabricspark/connections.py#L101-L117) dereferences `exc.args[0]` as a `thrift_resp` and reads `thrift_resp.status.errorMessage`. The adapter has no Thrift dependency — it talks to Fabric Livy over HTTP — so the branch is unreachable. It survives as a copy-paste from a `dbt-spark` ancestor.

This PR removes the dead branch and falls through to the existing `DbtRuntimeError(str(exc))` fallback that the `else` already pointed at.

## Diff

```diff
         except Exception as exc:
             logger.debug("Error while running:\n{}".format(sql))
             logger.debug(exc)
             if len(exc.args) == 0:
                 raise

-            thrift_resp = exc.args[0]
-            if hasattr(thrift_resp, "status"):
-                msg = thrift_resp.status.errorMessage
-                raise DbtRuntimeError(msg)
-            else:
-                raise DbtRuntimeError(str(exc))
+            raise DbtRuntimeError(str(exc))
```

`grep -ri thrift src/ tests/` returns nothing after the change.

## Test plan

- [ ] CI green on this branch.
- [ ] Manual: trigger any Livy error (e.g. a syntax error in a model) and confirm the original exception message still surfaces as a `DbtRuntimeError`. Behaviour is identical to the previous `else` branch — the deleted branch was never reached.
