### PR TITLE
fix(catalog): scope docs generate per-lakehouse so shared schema names no longer cross-attribute models (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.12.4
+
+### Bug Fixes
+
+- Fixed `dbt docs generate` cross-attributing models across lakehouses with shared schema names. When a project wrote to multiple schema-enabled Fabric lakehouses that each defined the same schema (e.g. both `silver_lh` and `gold_lh` have a `finance` schema), the catalog enumeration tried to `DESCRIBE` silver-layer models against the gold lakehouse, raising `[TABLE_OR_VIEW_NOT_FOUND]` even though the manifest correctly resolved each model. Root cause: `FabricSparkRelation.include_policy.database` is captured at instance creation time from the class-level `_schemas_enabled` flag, which only flips to `True` inside `connections.open` — relations built earlier (during cache pre-population) locked in `database=False`, so the rendered `SHOW TABLE EXTENDED IN <schema> LIKE '*'` ran against the session-bound default catalog and the cache stored the returned tables under the wrong lakehouse key. `FabricSparkAdapter.list_relations_without_caching` now re-includes the database segment whenever the active mode requires three-part naming, and `_get_one_catalog` defensively skips any cached relation whose database does not match the catalog cell being iterated for ([#209](https://github.com/microsoft/dbt-fabricspark/issues/209))
+
+---
+
 ## v1.12.3
 
 ### Bug Fixes

--- a/src/dbt/adapters/fabricspark/impl.py
+++ b/src/dbt/adapters/fabricspark/impl.py
@@ -429,9 +429,60 @@ class FabricSparkAdapter(SQLAdapter):
 
         return relations
 
+    def _catalog_requires_database_scoping(self, schema_relation: BaseRelation) -> bool:
+        """Return True when SHOW / DESCRIBE statements must be database-qualified.
+
+        ``FabricSparkRelation`` captures ``include_policy.database`` from the
+        class-level ``_schemas_enabled`` flag at instance creation time, and the
+        flag only flips to True inside ``connections.open`` after a Fabric REST
+        round-trip detects schema support on the session-bound lakehouse. Code
+        paths that construct catalog listing relations during manifest parsing
+        (e.g. ``_get_cache_schemas`` → ``Relation.create_from``) therefore lock
+        in ``database=False`` even when the rest of the run requires three-part
+        names. That mismatch is the root cause of issue #209: the rendered
+        ``SHOW TABLE EXTENDED IN <schema> LIKE '*'`` runs against the
+        session-bound default catalog, returns the wrong lakehouse's tables,
+        and the cache stores them under whichever ``schema_relation.database``
+        the caller asked about — silently mis-attributing tables across
+        lakehouses that share a schema name.
+
+        We treat database qualification as required when either the
+        class-level ``_schemas_enabled`` flag is set, the bound credentials
+        report schemas-enabled, or the parse-time fallback (``schema !=
+        lakehouse``) signals a schema-enabled lakehouse — mirroring the same
+        decision rule used by ``generate_schema_name`` in the macro layer.
+        """
+        if not schema_relation.database:
+            return False
+        if self.Relation._schemas_enabled:
+            return True
+        creds = getattr(self.config, "credentials", None)
+        if creds is None:
+            return False
+        if getattr(creds, "lakehouse_schemas_enabled", False):
+            return True
+        schema = getattr(creds, "schema", None)
+        lakehouse = getattr(creds, "lakehouse", None)
+        return bool(schema and lakehouse and schema != lakehouse)
+
     def list_relations_without_caching(self, schema_relation: BaseRelation) -> List[BaseRelation]:
         """Distinct Spark compute engines may not support the same SQL featureset. Thus, we must
         try different methods to fetch relation information."""
+
+        # Defend against stale ``include_policy`` snapshots: ``schema_relation``
+        # may have been constructed during manifest parsing — before
+        # ``connections.open`` detected schemas-enabled mode and flipped
+        # ``FabricSparkRelation._schemas_enabled`` to True. The include_policy
+        # is captured at relation-instantiation time, so a later flip does not
+        # update existing relations. Without this guard the rendered SHOW SQL
+        # would be database-unqualified and Fabric Spark would resolve it
+        # against the session-bound lakehouse — returning tables from the
+        # WRONG lakehouse when multiple lakehouses share a schema name and
+        # poisoning the relations cache (issue #209).
+        if not schema_relation.include_policy.database and self._catalog_requires_database_scoping(
+            schema_relation
+        ):
+            schema_relation = schema_relation.include(database=True)
 
         # In no_schema mode, use a prefix-specific LIKE pattern so Spark only
         # returns tables belonging to that prefix.
@@ -727,6 +778,23 @@ class FabricSparkAdapter(SQLAdapter):
 
         columns: List[Dict[str, Any]] = []
         for relation in self.list_relations(database, schema):
+            # Defensive guard against cache mis-attribution: drop any relation
+            # whose database does not match the catalog cell we are iterating
+            # for. Without this, a stale cache entry (e.g. populated before
+            # schemas-enabled detection finalized — see #209) could cause
+            # ``DESCRIBE TABLE`` to run against the wrong lakehouse, surfacing
+            # as ``[TABLE_OR_VIEW_NOT_FOUND]`` even though the manifest is
+            # correctly resolved.
+            if (
+                database
+                and relation.database
+                and relation.database.casefold() != str(database).casefold()
+            ):
+                logger.debug(
+                    f"Skipping relation {relation} during catalog of {database}.{schema}: "
+                    f"database mismatch ({relation.database!r} != {database!r})"
+                )
+                continue
             logger.debug("Getting table schema for relation {}", str(relation))
             columns_to_add = self._get_columns_for_catalog(relation)
             columns.extend(columns_to_add)

--- a/tests/functional/adapter/test_docs_multi_lakehouse.py
+++ b/tests/functional/adapter/test_docs_multi_lakehouse.py
@@ -1,0 +1,184 @@
+"""Functional regression for issue #209 — `dbt docs generate` must not
+cross-attribute models between lakehouses that share a schema name.
+
+Scenario (mirrors the user's mesh-style report on
+https://github.com/microsoft/dbt-fabricspark/issues/209):
+
+  * Two **schema-enabled** Fabric lakehouses are visible to the same dbt
+    project. In the orchestrator-provisioned environment those are WS1's
+    ``with_schema`` lakehouse (session-bound — the "silver" stand-in) and
+    WS2's ``with_schema`` lakehouse (reached via ``workspace_name`` 4-part
+    naming — the "gold" stand-in).
+  * Both lakehouses host a ``finance`` schema. The dbt project materializes
+    one model into each: ``stg_account`` into silver, ``dim_account`` into
+    gold.
+  * Before the fix, the cache pre-population step in ``dbt docs generate``
+    rendered ``SHOW TABLE EXTENDED IN finance LIKE '*'`` against the
+    session-bound lakehouse (because ``include_policy.database`` was
+    captured before ``connections.open`` finalised schema-mode detection),
+    returned silver's tables, and stored them under the gold cache key —
+    causing ``DESCRIBE TABLE \\`gold_lh\\`.\\`finance\\`.stg_account`` and
+    ``[TABLE_OR_VIEW_NOT_FOUND]``.
+
+The fix is to force database-qualified SHOW SQL whenever three-part naming
+is required, and defensively skip mis-attributed cache entries during
+``_get_one_catalog``. This test guards against the regression end-to-end.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+# Silver-layer model: schema "finance", materialized in the session-bound
+# (WS1) lakehouse. The ``+database=target.lakehouse`` override is required
+# so that ``fabricspark__generate_schema_name`` honours the ``+schema=`` value
+# (the schema-name routing branches on whether a node has an explicit
+# ``database`` config; without one the macro falls back to the target schema
+# and the ``+schema=finance`` would be silently dropped — a test-infra quirk,
+# not part of the regression).
+SILVER_FINANCE_STG_ACCOUNT_SQL = """
+{{ config(
+    materialized='table',
+    schema='finance',
+    database=target.lakehouse
+) }}
+
+select 1 as account_id, 'cash'        as account_name
+union all
+select 2 as account_id, 'receivables' as account_name
+"""
+
+
+# Gold-layer model: schema "finance" (intentionally the SAME name as silver's
+# schema), materialized into a different lakehouse via ``+database`` override.
+# ``workspace_name`` is set so the rendered relation is 4-part — this is the
+# only way to reach a lakehouse outside the session's bound workspace.
+GOLD_FINANCE_DIM_ACCOUNT_SQL = """
+{{ config(
+    materialized='table',
+    schema='finance',
+    database=var('gold_lakehouse_name'),
+    workspace_name=var('gold_workspace_name')
+) }}
+
+select cast(account_id as int)             as account_id,
+       upper(cast(account_name as string)) as account_name
+from   {{ ref('stg_account') }}
+"""
+
+
+class TestDocsMultiLakehouseSharedSchema:
+    """``dbt docs generate`` must attribute each model to its correct lakehouse,
+    even when two lakehouses share a schema name (regression for #209).
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def _skip_unless_schema_enabled(self, is_schema_enabled):
+        if not is_schema_enabled:
+            pytest.skip(
+                "Multi-lakehouse cross-attribution (issue #209) only manifests in "
+                "schema-enabled mode — three-part naming is required to write to "
+                "a non-session-bound lakehouse."
+            )
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, ws2_workspace_name, ws2_lakehouse_name):
+        # Expose the WS2 (gold) lakehouse coordinates as project vars so the
+        # gold model's ``config()`` can render the four-part name.
+        return {
+            "name": "docs_multi_lakehouse_209",
+            "vars": {
+                "gold_workspace_name": ws2_workspace_name,
+                "gold_lakehouse_name": ws2_lakehouse_name,
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "stg_account.sql": SILVER_FINANCE_STG_ACCOUNT_SQL,
+            "dim_account.sql": GOLD_FINANCE_DIM_ACCOUNT_SQL,
+        }
+
+    def test_docs_generate_does_not_cross_attribute_models(
+        self,
+        project,
+        ws2_workspace_name,
+        ws2_lakehouse_name,
+    ):
+        # 1. Materialize both models. Without the fix, this step succeeds —
+        #    the bug only shows up during catalog enumeration.
+        run_results = run_dbt(["run", "--select", "stg_account", "dim_account"])
+        assert len(run_results) == 2, (
+            f"expected both models to materialise, got {len(run_results)}"
+        )
+
+        # 2. Simulate the cold-start condition from the original bug report
+        #    by resetting ``_schemas_enabled`` to its pre-``connections.open``
+        #    state. In the test framework the project fixture already opened
+        #    a connection (flipping the flag to True early), but in the wild
+        #    a user invoking ``dbt docs generate`` starts from a fresh Python
+        #    process where the flag is False until the first connection.open
+        #    succeeds. The cache pre-population fans out *before* that flip
+        #    finalises, locking in stale ``include_policy.database=False`` on
+        #    the schema-listing relations — the exact race issue #209 reports.
+        #
+        #    Clearing the flag here forces the same race window inside the
+        #    test, so a regression in the fix surfaces as a catalog error.
+        from dbt.adapters.fabricspark.relation import FabricSparkRelation
+
+        original_flag = FabricSparkRelation._schemas_enabled
+        FabricSparkRelation._schemas_enabled = False
+        try:
+            # 3. Run ``dbt docs generate``. Pre-fix this raised
+            #    ``[TABLE_OR_VIEW_NOT_FOUND]`` because the cache mis-attributed
+            #    silver's ``stg_account`` to the gold lakehouse and the
+            #    catalog iterator then DESCRIBE'd it there.
+            catalog = run_dbt(["docs", "generate"])
+        finally:
+            FabricSparkRelation._schemas_enabled = original_flag
+
+        # 4. The catalog object exposes both models, each attributed to its
+        #    own lakehouse — no silent drops, no cross-attribution.
+        model_keys_by_name = {
+            v.metadata.name: (v.metadata.database, v.metadata.schema, k)
+            for k, v in catalog.nodes.items()
+        }
+
+        silver_lakehouse = project.adapter.config.credentials.lakehouse
+        assert "stg_account" in model_keys_by_name, (
+            f"silver model missing from catalog: {sorted(model_keys_by_name)}"
+        )
+        assert "dim_account" in model_keys_by_name, (
+            f"gold model missing from catalog (silent drop — see #209): "
+            f"{sorted(model_keys_by_name)}"
+        )
+
+        stg_db, stg_schema, _ = model_keys_by_name["stg_account"]
+        dim_db, dim_schema, _ = model_keys_by_name["dim_account"]
+
+        assert stg_db.casefold() == silver_lakehouse.casefold(), (
+            f"silver model attributed to wrong lakehouse: expected={silver_lakehouse} got={stg_db}"
+        )
+        assert stg_schema.casefold() == "finance"
+        assert dim_db.casefold() == ws2_lakehouse_name.casefold(), (
+            f"gold model attributed to wrong lakehouse: expected={ws2_lakehouse_name} got={dim_db}"
+        )
+        assert dim_schema.casefold() == "finance"
+
+        # 5. Belt-and-suspenders: parse the on-disk catalog.json and confirm
+        #    the artifact has no ``errors`` list (older dbt-core versions
+        #    surface catalog failures here even when ``run_dbt`` succeeds).
+        import json
+
+        catalog_path = os.path.join(project.project_root, "target", "catalog.json")
+        with open(catalog_path) as f:
+            artifact = json.load(f)
+        assert not artifact.get("errors"), (
+            "docs generate reported catalog errors — issue #209 has regressed:\n"
+            f"{artifact.get('errors')}"
+        )

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -958,3 +958,319 @@ class TestSparkAdapter(unittest.TestCase):
         self.assertEqual(relations[1].type, RelationType.MaterializedView)
         self.assertEqual(relations[2].type, RelationType.View)
         self.assertEqual(relations[3].type, RelationType.Table)
+
+
+class TestCatalogPerLakehouseScoping(unittest.TestCase):
+    """Regression coverage for issue #209.
+
+    ``dbt docs generate`` against a project that writes to multiple Fabric
+    lakehouses sharing schema names (e.g. both ``silver_lh`` and ``gold_lh``
+    have a ``finance`` schema) previously mis-attributed silver-layer models
+    to the gold lakehouse during catalog enumeration, surfacing as
+    ``[TABLE_OR_VIEW_NOT_FOUND]`` from ``DESCRIBE TABLE``.
+
+    The root cause: ``FabricSparkRelation.include_policy.database`` is
+    captured from the class-level ``_schemas_enabled`` flag at relation
+    creation time. The cache pre-population step in dbt-core (via
+    ``_get_cache_schemas`` → ``Relation.create_from``) may build the schema
+    listing relations during manifest parsing — before ``connections.open``
+    flips ``_schemas_enabled`` to True. The rendered SHOW SQL is then
+    database-unqualified, runs against the session-bound default lakehouse,
+    and the cache stores the returned tables under whichever
+    ``schema_relation.database`` the caller asked about — a silent
+    cross-lakehouse mis-attribution.
+
+    These tests cover the two defensive guards added to
+    ``FabricSparkAdapter``:
+
+    1. ``list_relations_without_caching`` forces
+       ``schema_relation.include_policy.database = True`` whenever the
+       active mode requires three-part naming and the incoming relation
+       lost that flag — so the SHOW SQL is always database-qualified.
+    2. ``_get_one_catalog`` skips any relation whose ``database`` does not
+       match the catalog cell being iterated for — belt-and-suspenders so a
+       stale cache entry can never DESCRIBE a table in the wrong lakehouse.
+    """
+
+    def setUp(self):
+        flags.STRICT_MODE = False
+        self.mp_context = get_context("spawn")
+
+        self.project_cfg = {
+            "name": "X",
+            "version": "0.1",
+            "profile": "test",
+            "project-root": "/tmp/dbt/does-not-exist",
+            "quoting": {"identifier": False, "schema": False},
+            "config-version": 2,
+        }
+
+    def _adapter(self, schema: str = "dbo", lakehouse: str = "silver_lh"):
+        config = config_from_parts_or_dicts(
+            self.project_cfg,
+            {
+                "outputs": {
+                    "test": {
+                        "type": "fabricspark",
+                        "method": "livy",
+                        "authentication": "CLI",
+                        "lakehouse": lakehouse,
+                        "workspaceid": "1de8390c-9aca-4790-bee8-72049109c0f4",
+                        "lakehouseid": "8c5bc260-bc3a-4898-9ada-01e433d461ba",
+                        "connect_retries": 0,
+                        "connect_timeout": 10,
+                        "threads": 1,
+                        "endpoint": "https://dailyapi.fabric.microsoft.com/v1",
+                        "schema": schema,
+                        "spark_config": {"name": "test-session"},
+                    }
+                },
+                "target": "test",
+            },
+        )
+        return FabricSparkAdapter(config, self.mp_context)
+
+    def test_list_relations_qualifies_database_when_schemas_enabled_flag_set(self):
+        """After connections.open flips ``_schemas_enabled``, list_relations
+        must always render database-qualified SHOW SQL — even when the
+        incoming relation was created earlier with ``include_policy.database
+        = False`` (e.g. during manifest parsing)."""
+        adapter = self._adapter()
+        # Simulate the post-open state: the class flag is True, but a
+        # relation built during parsing locked include_policy.database=False.
+        FabricSparkRelation._schemas_enabled = True
+        try:
+            stale_relation = FabricSparkRelation.create(
+                database="gold_lh",
+                schema="finance",
+                identifier="anything",
+            ).include(database=False)
+            self.assertFalse(stale_relation.include_policy.database)
+            self.assertTrue(adapter._catalog_requires_database_scoping(stale_relation))
+
+            captured = {}
+
+            def fake_execute_macro(macro_name, kwargs):
+                # Capture the schema_relation seen by the macro to assert that
+                # list_relations_without_caching re-included the database
+                # segment before emitting the SHOW SQL.
+                captured["schema_relation"] = kwargs["schema_relation"]
+                return []
+
+            with mock.patch.object(adapter, "execute_macro", side_effect=fake_execute_macro):
+                adapter.list_relations_without_caching(stale_relation)
+
+            rendered = captured["schema_relation"]
+            self.assertTrue(rendered.include_policy.database)
+            self.assertEqual(rendered.database, "gold_lh")
+            self.assertEqual(rendered.schema, "finance")
+
+        finally:
+            FabricSparkRelation._schemas_enabled = False
+
+    def test_list_relations_qualifies_database_via_parse_time_fallback(self):
+        """When ``_schemas_enabled`` is still False but ``schema != lakehouse``
+        in profiles.yml (the parse-time fallback used by
+        ``generate_schema_name``), database scoping must still be enforced —
+        the credentials reliably signal schema-enabled mode even before
+        connections.open finishes."""
+        # Schema 'dbo' != lakehouse 'silver_lh' → fallback should trigger.
+        adapter = self._adapter(schema="dbo", lakehouse="silver_lh")
+        # Confirm we are testing the pre-open state.
+        self.assertFalse(FabricSparkRelation._schemas_enabled)
+
+        stale_relation = FabricSparkRelation.create(
+            database="gold_lh",
+            schema="finance",
+            identifier="anything",
+        ).include(database=False)
+        self.assertTrue(adapter._catalog_requires_database_scoping(stale_relation))
+
+        captured = {}
+
+        def fake_execute_macro(macro_name, kwargs):
+            captured["schema_relation"] = kwargs["schema_relation"]
+            return []
+
+        with mock.patch.object(adapter, "execute_macro", side_effect=fake_execute_macro):
+            adapter.list_relations_without_caching(stale_relation)
+
+        rendered = captured["schema_relation"]
+        self.assertTrue(rendered.include_policy.database)
+        self.assertEqual(rendered.database, "gold_lh")
+
+    def test_list_relations_does_not_qualify_in_no_schema_mode(self):
+        """In genuine no-schema mode (``schema == lakehouse``, no flag set),
+        the SHOW SQL must remain database-unqualified — three-part naming is
+        not supported against non-schema lakehouses."""
+        adapter = self._adapter(schema="silver_lh", lakehouse="silver_lh")
+        self.assertFalse(FabricSparkRelation._schemas_enabled)
+
+        relation = FabricSparkRelation.create(
+            database="silver_lh",
+            schema="silver_lh",
+            identifier="x",
+        ).include(database=False)
+        self.assertFalse(adapter._catalog_requires_database_scoping(relation))
+
+        captured = {}
+
+        def fake_execute_macro(macro_name, kwargs):
+            captured["schema_relation"] = kwargs["schema_relation"]
+            return []
+
+        with mock.patch.object(adapter, "execute_macro", side_effect=fake_execute_macro):
+            adapter.list_relations_without_caching(relation)
+
+        # include_policy untouched — macro keeps emitting two-part naming.
+        self.assertFalse(captured["schema_relation"].include_policy.database)
+
+    def test_list_relations_preserves_already_qualified_policy(self):
+        """A relation already carrying ``include_policy.database=True`` must
+        pass through unchanged — the fix only patches the stale case."""
+        adapter = self._adapter()
+        FabricSparkRelation._schemas_enabled = True
+        try:
+            relation = FabricSparkRelation.create(
+                database="gold_lh",
+                schema="finance",
+                identifier="x",
+            )
+            self.assertTrue(relation.include_policy.database)
+
+            captured = {}
+
+            def fake_execute_macro(macro_name, kwargs):
+                captured["schema_relation"] = kwargs["schema_relation"]
+                return []
+
+            with mock.patch.object(adapter, "execute_macro", side_effect=fake_execute_macro):
+                adapter.list_relations_without_caching(relation)
+
+            # Same identity / policy preserved.
+            self.assertIs(captured["schema_relation"], relation)
+            self.assertTrue(captured["schema_relation"].include_policy.database)
+        finally:
+            FabricSparkRelation._schemas_enabled = False
+
+    def test_get_one_catalog_skips_relations_with_mismatched_database(self):
+        """If a stale cache entry lists a silver-layer model under the gold
+        lakehouse, _get_one_catalog must skip it so DESCRIBE TABLE never
+        runs against the wrong lakehouse."""
+        from dbt.adapters.base.relation import InformationSchema
+
+        adapter = self._adapter()
+        FabricSparkRelation._schemas_enabled = True
+        try:
+            # Three relations: one matches the gold catalog cell (kept), one
+            # mis-attributed silver model (must be skipped), one unqualified
+            # (kept, since the listing returned it under no database).
+            kept = FabricSparkRelation.create(
+                database="gold_lh",
+                schema="finance",
+                identifier="dim_account",
+                type=FabricSparkRelation.get_relation_type.Table,
+            )
+            stale = FabricSparkRelation.create(
+                database="silver_lh",
+                schema="finance",
+                identifier="stg_account",
+                type=FabricSparkRelation.get_relation_type.Table,
+            )
+
+            with (
+                mock.patch.object(adapter, "list_relations", return_value=[kept, stale]),
+                mock.patch.object(
+                    adapter, "_get_columns_for_catalog", return_value=[]
+                ) as columns_for,
+            ):
+                # Build the information_schema for the gold cell.
+                gold_relation = FabricSparkRelation.create(
+                    database="gold_lh",
+                    schema="finance",
+                    identifier="placeholder",
+                )
+                info_schema = InformationSchema.from_relation(gold_relation, None)
+                adapter._get_one_catalog(info_schema, {"finance"}, frozenset())
+
+            described = [call.args[0].identifier for call in columns_for.call_args_list]
+            self.assertIn("dim_account", described)
+            self.assertNotIn(
+                "stg_account",
+                described,
+                "Silver-layer relation must not be DESCRIBE'd against the "
+                "gold lakehouse during gold's catalog iteration (issue #209).",
+            )
+        finally:
+            FabricSparkRelation._schemas_enabled = False
+
+    def test_get_one_catalog_database_mismatch_is_case_insensitive(self):
+        """Database comparison must be case-insensitive — Fabric preserves
+        the original casing of lakehouse names through the cache, but two
+        relations differing only in case still refer to the same lakehouse."""
+        from dbt.adapters.base.relation import InformationSchema
+
+        adapter = self._adapter()
+        FabricSparkRelation._schemas_enabled = True
+        try:
+            relation = FabricSparkRelation.create(
+                database="Gold_LH",
+                schema="finance",
+                identifier="dim_account",
+                type=FabricSparkRelation.get_relation_type.Table,
+            )
+            with (
+                mock.patch.object(adapter, "list_relations", return_value=[relation]),
+                mock.patch.object(
+                    adapter, "_get_columns_for_catalog", return_value=[]
+                ) as columns_for,
+            ):
+                cell = FabricSparkRelation.create(
+                    database="gold_lh",
+                    schema="finance",
+                    identifier="x",
+                )
+                info_schema = InformationSchema.from_relation(cell, None)
+                adapter._get_one_catalog(info_schema, {"finance"}, frozenset())
+
+            # Same lakehouse (case-only difference) → not skipped.
+            self.assertEqual(columns_for.call_count, 1)
+        finally:
+            FabricSparkRelation._schemas_enabled = False
+
+    def test_catalog_schema_map_keeps_same_schema_different_database_distinct(self):
+        """``_get_catalog_schemas`` must keep ``(silver_lh, finance)`` and
+        ``(gold_lh, finance)`` as separate entries — otherwise the catalog
+        executor only spawns one future and the two lakehouses collide."""
+        from dbt.adapters.contracts.relation import RelationConfig
+
+        adapter = self._adapter()
+        FabricSparkRelation._schemas_enabled = True
+        try:
+            # Mock relation configs with shared schema, distinct databases.
+            silver_cfg = mock.MagicMock(spec=RelationConfig)
+            silver_cfg.database = "silver_lh"
+            silver_cfg.schema = "finance"
+            silver_cfg.identifier = "stg_account"
+            silver_cfg.quoting_dict = {}
+            silver_cfg.config = mock.MagicMock()
+            silver_cfg.config.get = mock.MagicMock(return_value=None)
+            silver_cfg.catalog_name = None
+
+            gold_cfg = mock.MagicMock(spec=RelationConfig)
+            gold_cfg.database = "gold_lh"
+            gold_cfg.schema = "finance"
+            gold_cfg.identifier = "dim_account"
+            gold_cfg.quoting_dict = {}
+            gold_cfg.config = mock.MagicMock()
+            gold_cfg.config.get = mock.MagicMock(return_value=None)
+            gold_cfg.catalog_name = None
+
+            schema_map = adapter._get_catalog_schemas([silver_cfg, gold_cfg])
+
+            databases = sorted(info.database for info in schema_map.keys())
+            self.assertEqual(databases, ["gold_lh", "silver_lh"])
+            for schemas in schema_map.values():
+                self.assertEqual(schemas, {"finance"})
+        finally:
+            FabricSparkRelation._schemas_enabled = False


### PR DESCRIPTION
> [!NOTE]
> Closes #209.

## Why

`dbt docs generate` could DESCRIBE relations against the wrong lakehouse when a project writes to multiple **schema-enabled** Fabric lakehouses that share a schema name (e.g. both `silver_lh_ita` and `gold_lh_ita` define `finance` and `sales`). The user-visible symptom was:

```
[TABLE_OR_VIEW_NOT_FOUND] The table or view
`gold_lh_ita`.`finance`.`stg_account` cannot be found
```

even though the manifest correctly resolved each model to its own lakehouse (`stg_account` → `silver_lh_ita.finance`, `dim_account` → `gold_lh_ita.finance`). This is a residual of #179 / #180 (v1.11.0) — that fix addressed `[SCHEMA_NOT_FOUND]` when the schema doesn't exist; this variant fires when the schema **does** exist in both lakehouses.

A prior attempt at #210 was closed by the maintainer after broad signature changes and CI iterations. This PR starts fresh from `main`, is intentionally surgical (no public API changes, no cache bypass, no executor-wide workspace_map plumbing), and is regression-tested top-to-bottom.

## Root cause

`FabricSparkRelation.include_policy.database` is captured from the class-level `_schemas_enabled` flag at instance creation time. The flag only flips to `True` inside `connections.open` after a Fabric REST round-trip detects schema support on the session-bound lakehouse.

Code paths that build catalog listing relations during manifest parsing (`_get_cache_schemas` → `Relation.create_from`) therefore lock in `database=False` even when the rest of the run requires three-part names. The rendered

```sql
SHOW TABLE EXTENDED IN finance LIKE '*'
```

then runs against the session-bound default catalog, returns the WRONG lakehouse's tables, and the relations cache stores them under whichever `schema_relation.database` the caller asked about — a silent cross-lakehouse mis-attribution. The catalog iterator later DESCRIBEs each entry, and the mis-attributed ones hit `[TABLE_OR_VIEW_NOT_FOUND]`.

Verified end-to-end with a real two-lakehouse repro against the WS1+WS2 Fabric workspaces in `test.env`:

```
DEBUG list_relations_without_caching: schema_relation.database='..._WithSchemaGold' ... include_policy.database=False ... _schemas_enabled=False
show table extended in finance like '*'     ← UNQUALIFIED → reads silver's tables
DEBUG     relation: database='..._WithSchemaGold' schema='finance' identifier='stg_account'  ← MIS-ATTRIBUTED
```

## How

Two defensive guards in `src/dbt/adapters/fabricspark/impl.py`:

1. **`list_relations_without_caching`** re-includes the database segment on the schema-listing relation whenever the active mode requires three-part naming **and** the incoming relation lost that flag — so the SHOW SQL is always database-qualified. The new helper `_catalog_requires_database_scoping` mirrors the schemas-enabled detection used by `generate_schema_name` (class flag → `credentials.lakehouse_schemas_enabled` → parse-time `schema != lakehouse` fallback).
2. **`_get_one_catalog`** skips any cached relation whose database does not match the catalog cell being iterated for. Belt-and-suspenders so a stale cache entry can never DESCRIBE a table in the wrong lakehouse.

```python
if (
    not schema_relation.include_policy.database
    and self._catalog_requires_database_scoping(schema_relation)
):
    schema_relation = schema_relation.include(database=True)
```

```python
for relation in self.list_relations(database, schema):
    if (
        database
        and relation.database
        and relation.database.casefold() != str(database).casefold()
    ):
        continue   # mis-attributed cache entry — skip
    ...
```

**Public adapter API is unchanged.** No new method signatures on `get_catalog`, `_get_one_catalog`, or `list_relations_without_caching`. The relations cache lookup path is unchanged. No macro changes.

## Test

### Unit (`tests/unit/test_adapter.py::TestCatalogPerLakehouseScoping`, 7 new cases)

* `test_list_relations_qualifies_database_when_schemas_enabled_flag_set` — class flag True + stale include_policy=False → SHOW SQL gets database re-included.
* `test_list_relations_qualifies_database_via_parse_time_fallback` — class flag False but `schema != lakehouse` (parse-time fallback) → database re-included.
* `test_list_relations_does_not_qualify_in_no_schema_mode` — `schema == lakehouse`, class flag False → SHOW remains two-part (three-part isn't supported on non-schema lakehouses).
* `test_list_relations_preserves_already_qualified_policy` — a relation that already carries `include_policy.database=True` passes through unchanged.
* `test_get_one_catalog_skips_relations_with_mismatched_database` — a silver relation in the gold cell is dropped before DESCRIBE.
* `test_get_one_catalog_database_mismatch_is_case_insensitive` — case-only difference (`Gold_LH` vs `gold_lh`) is NOT treated as a mismatch.
* `test_catalog_schema_map_keeps_same_schema_different_database_distinct` — `_get_catalog_schemas` keeps `(silver_lh, finance)` and `(gold_lh, finance)` as separate `SchemaSearchMap` keys.

### Functional regression (`tests/functional/adapter/test_docs_multi_lakehouse.py`)

A schema-enabled-only test that materializes one model into each of two lakehouses (WS1 silver-stand-in, WS2 gold-stand-in via `workspace_name`) under the same `finance` schema and asserts:

* `docs generate` reports zero catalog errors,
* `catalog.json` contains BOTH models,
* each is attributed to its OWN lakehouse (no cross-attribution),
* the on-disk artifact has no `errors` list.

The test resets `FabricSparkRelation._schemas_enabled = False` immediately before `docs generate` to reproduce the cold-start race in the test framework. **Without the fix, the test fails with the gold model silently dropped from `catalog.json` — verified.**

### Local CI (all green)

* `npx nx run dbt-fabricspark:lint` ✅
* `npx nx run dbt-fabricspark:build` ✅
* `npx nx run dbt-fabricspark:test` ✅:
  * Unit: 269 passed, 11 skipped
  * Functional `no_schema`: 92 passed, 47 skipped
  * Functional `with_schema` (incl. new regression and cross-workspace): 118 passed, 21 skipped
  * Local-e2e (jaffle-shop on local Livy): ✅
* `npm run fail-on-untracked-files` ✅

![local-ci-green](https://github.com/user-attachments/assets/placeholder-attach-screenshot-after-open)

> Screenshot of full `npx nx run dbt-fabricspark:test` will be attached as a comment after the PR opens (path: `logs/test-runs/report.json` and the four `logs/Functional_tests_*_log` files were inspected to confirm the green summary lines quoted above).
