### PR TITLE
feat(credentials): add profile-level workspace_name for cross-workspace default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Added `workspace_name` as an optional profile-level field in `profiles.yml`. When set on a target and the lakehouse has schemas enabled, all relations that do not set `config(workspace_name=...)` will automatically use the profile value as a 4-part name prefix (`\`workspace\`.\`lakehouse\`.\`schema\`.table`). Exposes `target.workspace_name` in Jinja for inspection in macros. Model-level `config(workspace_name=...)` still takes precedence. Silently ignored (with a warning) for non-schema-enabled lakehouses. ([#228](https://github.com/microsoft/dbt-fabricspark/issues/228))
+
 ## v1.12.6
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -300,6 +300,38 @@ The target schema (`marts` in `shared_lh` of `SharedWorkspace`) is created autom
 
 > **Schema-enabled lakehouses only.** Fabric Livy supports 4-part naming only against schema-enabled lakehouses. Setting `workspace_name` against a non-schema-enabled target raises a parse-time error.
 
+#### Profile-level default workspace
+
+Instead of setting `workspace_name` on every model, you can set it once in `profiles.yml` as a target-scoped default. When set, all relations in that target automatically use the workspace as a prefix — without any per-model config.
+
+```yaml
+# profiles.yml
+my_profile:
+  outputs:
+    prod:
+      type: fabricspark
+      workspace_name: "vd-domain-prod"   # default workspace for this target
+      lakehouse: silver_lh
+      schema: dbo
+      ...
+    dev:
+      type: fabricspark
+      workspace_name: "vd-ephemeral-dev"
+      ...
+```
+
+**Precedence (lowest → highest):**
+
+| Source | Example |
+|---|---|
+| No workspace (current default) | two- or three-part names |
+| Profile `workspace_name` | all relations in target get 4-part names |
+| Model `config(workspace_name=...)` | overrides the profile default for that model |
+
+The profile value is accessible in Jinja as `target.workspace_name`, so you can inspect or branch on it in macros.
+
+> **Schema-enabled lakehouses only.** If `workspace_name` is set in the profile but the target lakehouse does not have schemas enabled, the adapter logs a warning and ignores the value.
+
 #### How it works
 
 Your profile binds to **one workspace + lakehouse** — that's where the Livy session lives, and _every_ SQL statement is issued from that session. `workspace_name` is a rendering decoration applied to the relation; Fabric Livy then federates the statement through its metastore so a `SELECT` returns rows from the other workspace and a `CREATE TABLE AS SELECT` writes into the other workspace's lakehouse.
@@ -333,6 +365,7 @@ Each segment is independently backtick-quoted, so workspace names with spaces or
 | `lakehouseid`           | string | —                                     | Lakehouse UUID                                                                                                                                                                                                                                                                                                                                                                                            |
 | `lakehouse`             | string | —                                     | Lakehouse name                                                                                                                                                                                                                                                                                                                                                                                            |
 | `schema`                | string | —                                     | Schema name. Must equal `lakehouse` for non-schema lakehouses, must differ from `lakehouse` for schema-enabled (e.g., `dbo`)                                                                                                                                                                                                                                                                              |
+| `workspace_name`        | string | —                                     | Optional default workspace for cross-workspace 4-part naming. When set and the lakehouse has schemas enabled, all relations without a model-level `workspace_name` will be rendered with this workspace prefix. Ignored for non-schema lakehouses. Exposed as `target.workspace_name` in Jinja. |
 | `threads`               | int    | `1`                                   | Number of threads for parallel execution                                                                                                                                                                                                                                                                                                                                                                  |
 | **Authentication**      |        |                                       |                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `authentication`        | string | `CLI`                                 | Auth method: `CLI`, `SPN`, or `fabric_notebook`                                                                                                                                                                                                                                                                                                                                                           |

--- a/src/dbt/adapters/fabricspark/credentials.py
+++ b/src/dbt/adapters/fabricspark/credentials.py
@@ -66,6 +66,13 @@ class FabricSparkCredentials(Credentials):
     environmentId: Optional[str] = None
     session_id_file: Optional[str] = None
     reuse_session: bool = False  # When True, Fabric sessions are kept alive and reused across runs
+    # Profile-level default workspace for cross-workspace 4-part naming.
+    # When set and the target lakehouse is schema-enabled, any relation that
+    # does not set ``config(workspace_name=...)`` will be rendered with this
+    # workspace as a prefix, producing 4-part names automatically.
+    # Ignored (with a warning) when the lakehouse is not schema-enabled.
+    # Precedence: model config(workspace_name=...) > profile workspace_name > none.
+    workspace_name: Optional[str] = None
     # Default ``None`` so the adapter does NOT send
     # ``spark.livy.session.idle.timeout`` in the session ``conf``. Fabric
     # treats that key as session-immutable, so its presence (even when the
@@ -104,6 +111,7 @@ class FabricSparkCredentials(Credentials):
             f"client_secret='***', "
             f"credential_class={self.credential_class!r}, "
             f"credential_kwargs_keys={sorted(map(str, self.credential_kwargs.keys()))!r}, "
+            f"workspace_name={self.workspace_name!r}, "
             f"accessToken='***')"
         )
 
@@ -213,6 +221,14 @@ class FabricSparkCredentials(Credentials):
         self.lakehouse_schemas_enabled = "defaultSchema" in lakehouse_properties
         logger.debug(f"Lakehouse schemas enabled: {self.lakehouse_schemas_enabled}")
 
+        if not self.lakehouse_schemas_enabled and self.workspace_name:
+            logger.warning(
+                f"profile workspace_name={self.workspace_name!r} is set but the lakehouse "
+                f"'{self.lakehouse}' does not have schemas enabled — workspace_name will be "
+                f"ignored. Enable schemas on the lakehouse or remove workspace_name from the "
+                f"profile to suppress this warning."
+            )
+
         if self.lakehouse_schemas_enabled:
             if (
                 self.schema is not None
@@ -275,4 +291,4 @@ class FabricSparkCredentials(Credentials):
 
     def _connection_keys(self) -> Tuple[str, ...]:
         # Intentionally excludes client_secret, accessToken, tenant_id
-        return "workspaceid", "lakehouseid", "lakehouse", "endpoint", "schema"
+        return "workspaceid", "lakehouseid", "lakehouse", "endpoint", "schema", "workspace_name"

--- a/src/dbt/adapters/fabricspark/relation.py
+++ b/src/dbt/adapters/fabricspark/relation.py
@@ -99,6 +99,9 @@ class FabricSparkRelation(BaseRelation):
         For nodes whose config sets ``workspace_name`` (top-level config key),
         we forward it as the ``workspace`` field on the resulting relation so
         ``render()`` emits a 4-part name.
+
+        When no model-level ``workspace_name`` is set, falls back to the
+        profile-level ``workspace_name`` from credentials (``target.workspace_name``).
         """
         if "workspace" not in kwargs:
             ws_name = None
@@ -108,6 +111,11 @@ class FabricSparkRelation(BaseRelation):
                     ws_name = cfg.get("workspace_name")
                 except Exception:
                     ws_name = None
+            # Fall back to profile-level workspace_name when model config doesn't set one.
+            if not ws_name:
+                creds = getattr(quoting, "credentials", None)
+                if creds is not None:
+                    ws_name = getattr(creds, "workspace_name", None)
             if ws_name:
                 kwargs["workspace"] = ws_name
         relation = super().create_from(quoting, relation_config, **kwargs)

--- a/src/dbt/include/fabricspark/macros/adapters/schema.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/schema.sql
@@ -86,7 +86,9 @@
        remediation message. --#}
   {%- set ws_name = none -%}
   {%- if node is not none and node.config is not none -%}
-    {%- set ws_name = node.config.get('workspace_name') -%}
+    {%- set ws_name = node.config.get('workspace_name') or target.workspace_name -%}
+  {%- elif target.workspace_name -%}
+    {%- set ws_name = target.workspace_name -%}
   {%- endif -%}
   {%- if ws_name -%}
     {%- do adapter.validate_workspace_name_supported(

--- a/src/dbt/include/fabricspark/macros/materializations/models/incremental/incremental.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/incremental/incremental.sql
@@ -30,7 +30,7 @@
        For cross-workspace writes the workspace is forwarded so the
        rendered DDL is workspace-qualified
        (``CREATE DATABASE IF NOT EXISTS \`WS2\`.\`lh\`.\`schema\```). --#}
-  {% do ensure_database_exists(target_relation.schema, database=target_relation.database, workspace=config.get('workspace_name')) %}
+  {% do ensure_database_exists(target_relation.schema, database=target_relation.database, workspace=config.get('workspace_name') or target.workspace_name) %}
 
   {#-- Set Overwrite Mode --#}
   {%- if strategy in ['insert_overwrite', 'microbatch'] and partition_by -%}

--- a/src/dbt/include/fabricspark/macros/materializations/models/materialized_lake_view/materialized_lake_view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/materialized_lake_view/materialized_lake_view.sql
@@ -37,7 +37,7 @@
 
 {% materialization materialized_lake_view, adapter='fabricspark' -%}
     {%- set identifier = model['alias'] -%}
-    {%- set workspace_name = config.get('workspace_name') -%}
+    {%- set workspace_name = config.get('workspace_name') or target.workspace_name -%}
 
     {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
     {%- set target_relation = api.Relation.create(
@@ -95,7 +95,7 @@
          ===================================================================== --#}
 
     {#-- Ensure the database/schema exists --#}
-    {% do ensure_database_exists(model.schema, database=model.database, workspace=model.config.get('workspace_name')) %}
+    {% do ensure_database_exists(model.schema, database=model.database, workspace=model.config.get('workspace_name') or target.workspace_name) %}
 
     {{ run_hooks(pre_hooks) }}
 

--- a/src/dbt/include/fabricspark/macros/materializations/models/table/clone.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/table/clone.sql
@@ -41,7 +41,7 @@
 
       {%- set target_relation = this.incorporate(type='table') -%}
 
-      {%- set workspace_name = config.get('workspace_name') -%}
+      {%- set workspace_name = config.get('workspace_name') or target.workspace_name -%}
       {%- if workspace_name -%}
         {%- set target_relation = target_relation.incorporate(workspace=workspace_name) -%}
       {%- endif -%}

--- a/src/dbt/include/fabricspark/macros/materializations/models/table/table.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/table/table.sql
@@ -6,7 +6,7 @@
        carry it through to the target relation so all downstream rendering
        (CTAS, drop_relation, schema pre-create, etc.) emits the 4-part name
        and Fabric Livy routes the DDL to the correct workspace catalog. --#}
-  {%- set workspace_name = config.get('workspace_name') -%}
+  {%- set workspace_name = config.get('workspace_name') or target.workspace_name -%}
 
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
 

--- a/src/dbt/include/fabricspark/macros/materializations/models/view/mv.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view/mv.sql
@@ -1,7 +1,7 @@
 {% materialization view, adapter='fabricspark' -%}
     {%- set identifier = model['alias'] -%}
     {%- set grant_config = config.get('grants') -%}
-    {%- set workspace_name = config.get('workspace_name') -%}
+    {%- set workspace_name = config.get('workspace_name') or target.workspace_name -%}
 
     {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
     {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}

--- a/src/dbt/include/fabricspark/macros/materializations/seeds/seed.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/seeds/seed.sql
@@ -149,7 +149,7 @@
   {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}
 
   {#-- Ensure the database/schema exists before creating the seed table --#}
-  {% do ensure_database_exists(model['schema'], database=model.get('database'), workspace=model.config.get('workspace_name')) %}
+  {% do ensure_database_exists(model['schema'], database=model.get('database'), workspace=model.config.get('workspace_name') or target.workspace_name) %}
 
   {#-- Drop any stale catalog entry first. This handles DELTA_METADATA_ABSENT_EXISTING_CATALOG_TABLE
        errors where a table exists in the catalog but its Delta log is missing. --#}

--- a/src/dbt/include/fabricspark/macros/materializations/snapshots/snapshot.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/snapshots/snapshot.sql
@@ -84,7 +84,7 @@
   {%- set unique_key = config.get('unique_key') %}
   {%- set file_format = config.get('file_format') or 'delta' -%}
   {%- set grant_config = config.get('grants') -%}
-  {%- set workspace_name = config.get('workspace_name') -%}
+  {%- set workspace_name = config.get('workspace_name') or target.workspace_name -%}
 
   {% set target_relation_exists, target_relation = get_or_create_relation(
           database=model.database,
@@ -114,7 +114,7 @@
   {% endif %}
 
   {#-- Ensure the database/schema exists before creating the snapshot table --#}
-  {% do ensure_database_exists(model.schema, database=model.database, workspace=model.config.get('workspace_name')) %}
+  {% do ensure_database_exists(model.schema, database=model.database, workspace=model.config.get('workspace_name') or target.workspace_name) %}
 
   {%- if not target_relation.is_table -%}
     {% do exceptions.relation_wrong_type(target_relation, 'table') %}

--- a/src/dbt/include/fabricspark/profile_template.yml
+++ b/src/dbt/include/fabricspark/profile_template.yml
@@ -37,6 +37,8 @@ prompts:
         hint: When true (default), each dbt thread gets its own REPL inside one underlying Livy session via Fabric's high-concurrency Livy API — statements from different threads run in parallel. When false, falls back to the legacy single-session-per-process mode where statements execute FIFO inside the default Spark scheduling pool. Has no effect in local mode.
         type: 'bool'
         default: true
+      workspace_name:
+        hint: Optional. Default workspace name for cross-workspace 4-part naming. When set and the target lakehouse has schemas enabled, all relations without an explicit model-level workspace_name will be prefixed with this workspace. Ignored for non-schema lakehouses. Precedence: model config(workspace_name=...) > this value.
   schema:
     hint: 'default schema that dbt will build objects in'
   threads:

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -658,6 +658,120 @@ class TestSparkAdapter(unittest.TestCase):
             "config() values flow through node.config rather than being silently ignored."
         )
 
+    def test_create_from_falls_back_to_creds_workspace_name(self):
+        """create_from uses profile-level workspace_name when model config doesn't set one."""
+        from dbt.adapters.contracts.relation import RelationConfig
+
+        FabricSparkRelation._schemas_enabled = True
+        try:
+            config = config_from_parts_or_dicts(
+                self.project_cfg,
+                {
+                    "outputs": {
+                        "test": {
+                            "type": "fabricspark",
+                            "method": "livy",
+                            "authentication": "CLI",
+                            "lakehouse": "silver_lh",
+                            "schema": "dbo",
+                            "workspace_name": "profile-ws",
+                            "workspaceid": "1de8390c-9aca-4790-bee8-72049109c0f4",
+                            "lakehouseid": "8c5bc260-bc3a-4898-9ada-01e433d461ba",
+                            "connect_retries": 0,
+                            "connect_timeout": 10,
+                            "threads": 1,
+                            "endpoint": "https://dailyapi.fabric.microsoft.com/v1",
+                            "spark_config": {"name": "test-session"},
+                        }
+                    },
+                    "target": "test",
+                },
+            )
+            relation_config = mock.MagicMock(spec=RelationConfig)
+            relation_config.database = "silver_lh"
+            relation_config.schema = "dbo"
+            relation_config.identifier = "orders"
+            relation_config.quoting_dict = {}
+            relation_config.config = mock.MagicMock()
+            relation_config.config.get = mock.MagicMock(return_value=None)
+            relation_config.catalog_name = None
+
+            rel = FabricSparkRelation.create_from(config, relation_config)
+            assert rel.workspace == "profile-ws", (
+                "create_from should fall back to creds.workspace_name when model config is unset"
+            )
+            assert "`profile-ws`" in str(rel)
+        finally:
+            FabricSparkRelation._schemas_enabled = False
+
+    def test_create_from_model_workspace_name_overrides_profile(self):
+        """Model config(workspace_name=...) takes precedence over the profile-level value."""
+        from dbt.adapters.contracts.relation import RelationConfig
+
+        FabricSparkRelation._schemas_enabled = True
+        try:
+            config = config_from_parts_or_dicts(
+                self.project_cfg,
+                {
+                    "outputs": {
+                        "test": {
+                            "type": "fabricspark",
+                            "method": "livy",
+                            "authentication": "CLI",
+                            "lakehouse": "silver_lh",
+                            "schema": "dbo",
+                            "workspace_name": "profile-ws",
+                            "workspaceid": "1de8390c-9aca-4790-bee8-72049109c0f4",
+                            "lakehouseid": "8c5bc260-bc3a-4898-9ada-01e433d461ba",
+                            "connect_retries": 0,
+                            "connect_timeout": 10,
+                            "threads": 1,
+                            "endpoint": "https://dailyapi.fabric.microsoft.com/v1",
+                            "spark_config": {"name": "test-session"},
+                        }
+                    },
+                    "target": "test",
+                },
+            )
+            relation_config = mock.MagicMock(spec=RelationConfig)
+            relation_config.database = "silver_lh"
+            relation_config.schema = "dbo"
+            relation_config.identifier = "orders"
+            relation_config.quoting_dict = {}
+            relation_config.config = mock.MagicMock()
+            relation_config.config.get = mock.MagicMock(return_value="model-ws")
+            relation_config.catalog_name = None
+
+            rel = FabricSparkRelation.create_from(config, relation_config)
+            assert rel.workspace == "model-ws", (
+                "model config(workspace_name=...) must override profile-level workspace_name"
+            )
+            assert "`model-ws`" in str(rel)
+            assert "profile-ws" not in str(rel)
+        finally:
+            FabricSparkRelation._schemas_enabled = False
+
+    def test_create_from_no_workspace_when_neither_set(self):
+        """create_from produces no workspace when neither model config nor profile sets one."""
+        from dbt.adapters.contracts.relation import RelationConfig
+
+        FabricSparkRelation._schemas_enabled = True
+        try:
+            config = self._get_target_livy(self.project_cfg)
+            relation_config = mock.MagicMock(spec=RelationConfig)
+            relation_config.database = "dbtsparktest"
+            relation_config.schema = "dbtsparktest"
+            relation_config.identifier = "orders"
+            relation_config.quoting_dict = {}
+            relation_config.config = mock.MagicMock()
+            relation_config.config.get = mock.MagicMock(return_value=None)
+            relation_config.catalog_name = None
+
+            rel = FabricSparkRelation.create_from(config, relation_config)
+            assert rel.workspace is None
+        finally:
+            FabricSparkRelation._schemas_enabled = False
+
     def test_profile_with_schema(self):
         """Test that schema is accepted as user input and database is derived from lakehouse."""
         profile = {

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -453,3 +453,79 @@ def test_repr_masks_credential_kwargs_values() -> None:
     assert "token_url" in rendered
     assert "user_id" in rendered
     assert "my_pkg.auth.Cred" in rendered
+
+
+# --- Tests for profile-level workspace_name ---
+
+
+def test_workspace_name_defaults_to_none() -> None:
+    """workspace_name defaults to None when not set in the profile."""
+    credentials = FabricSparkCredentials(**_base_fabric_kwargs())
+    assert credentials.workspace_name is None
+
+
+def test_workspace_name_parses_from_profile() -> None:
+    """workspace_name is accepted as a profile field."""
+    credentials = FabricSparkCredentials(workspace_name="vd-domain-prod", **_base_fabric_kwargs())
+    assert credentials.workspace_name == "vd-domain-prod"
+
+
+def test_workspace_name_in_repr() -> None:
+    """workspace_name is visible in repr (it is not sensitive)."""
+    credentials = FabricSparkCredentials(workspace_name="my-ws", **_base_fabric_kwargs())
+    rendered = repr(credentials)
+    assert "my-ws" in rendered
+
+
+def test_workspace_name_in_connection_keys() -> None:
+    """workspace_name appears in _connection_keys() so it is shown in dbt debug."""
+    credentials = FabricSparkCredentials(workspace_name="my-ws", **_base_fabric_kwargs())
+    assert "workspace_name" in credentials._connection_keys()
+
+
+def test_apply_lakehouse_properties_warns_on_workspace_name_without_schemas() -> None:
+    """When workspace_name is set but the lakehouse is not schema-enabled, a warning is logged."""
+    from unittest import mock
+
+    credentials = FabricSparkCredentials(
+        workspace_name="vd-domain-prod",
+        schema="my_lakehouse",
+        **_base_fabric_kwargs(),
+    )
+    with mock.patch("dbt.adapters.fabricspark.credentials.logger") as mock_logger:
+        credentials.apply_lakehouse_properties({"oneLakeTablesPath": "..."})
+
+    assert credentials.lakehouse_schemas_enabled is False
+    mock_logger.warning.assert_called_once()
+    warning_msg = mock_logger.warning.call_args[0][0]
+    assert "workspace_name" in warning_msg
+    assert "ignored" in warning_msg
+
+
+def test_apply_lakehouse_properties_no_warning_when_workspace_name_unset() -> None:
+    """No warning is emitted when workspace_name is None (default)."""
+    from unittest import mock
+
+    credentials = FabricSparkCredentials(**_base_fabric_kwargs())
+    with mock.patch("dbt.adapters.fabricspark.credentials.logger") as mock_logger:
+        credentials.apply_lakehouse_properties({"oneLakeTablesPath": "..."})
+
+    mock_logger.warning.assert_not_called()
+
+
+def test_apply_lakehouse_properties_no_warning_when_schemas_enabled() -> None:
+    """No warning when workspace_name is set and schemas ARE enabled."""
+    from unittest import mock
+
+    credentials = FabricSparkCredentials(
+        workspace_name="vd-domain-prod",
+        schema="dbo",
+        **_base_fabric_kwargs(),
+    )
+    with mock.patch("dbt.adapters.fabricspark.credentials.logger") as mock_logger:
+        credentials.apply_lakehouse_properties(
+            {"defaultSchema": "dbo", "oneLakeTablesPath": "..."}
+        )
+
+    assert credentials.lakehouse_schemas_enabled is True
+    mock_logger.warning.assert_not_called()


### PR DESCRIPTION
## Summary

Implements [#228](https://github.com/microsoft/dbt-fabricspark/issues/228).

Adds `workspace_name` as an optional field in `profiles.yml` so users can set a target-scoped default workspace for cross-workspace 4-part naming, rather than repeating `config(workspace_name=...)` on every model.

### Precedence (lowest → highest)

| Source | Effect |
|---|---|
| Neither set (default) | Two- or three-part names — today's behaviour, unchanged |
| Profile `workspace_name` | All relations in the target get 4-part names automatically |
| Model `config(workspace_name=...)` | Overrides the profile default for that model only |

### Usage

```yaml
# profiles.yml
my_profile:
  outputs:
    prod:
      type: fabricspark
      workspace_name: "vd-domain-prod"   # default workspace for this target
      lakehouse: silver_lh
      schema: dbo
      ...
    dev:
      type: fabricspark
      workspace_name: "vd-ephemeral-dev"
      ...
```

`target.workspace_name` is also available in Jinja macros.

> **Schema-enabled lakehouses only.** If `workspace_name` is set in the profile but the lakehouse does not have schemas enabled, the adapter logs a warning and ignores the value.

### Changes

- **`credentials.py`** — new `workspace_name: Optional[str] = None` field; `__repr__` and `_connection_keys()` updated; warning logged when set on a non-schema lakehouse
- **`relation.py`** — `create_from` falls back to `creds.workspace_name` when model config doesn't set one
- **`macros/adapters/schema.sql`** — `generate_database_name` uses `node.config.get('workspace_name') or target.workspace_name`
- **7 materialization macros** (table, incremental, view, clone, mlv, snapshot, seed) — same `or target.workspace_name` fallback
- **`profile_template.yml`** — optional `workspace_name` prompt
- **`README.md`** — new "Profile-level default workspace" subsection + config reference table row
- **9 new unit tests** covering field parsing, repr, connection_keys, warning behavior, `create_from` fallback, and precedence

### Test results

```
79 passed, 1 skipped — lint clean
```