### PR TITLE
fix: prevent zero-memory Spark driver

### DIFF
--- a/.devcontainer/devcontainer.test.ts
+++ b/.devcontainer/devcontainer.test.ts
@@ -62,6 +62,21 @@ describe('Devcontainer Tests', () => {
     },
   );
 
+  test('Spark memory allocation does not truncate a valid percentage to zero', () => {
+    const script = readFileSync(
+      join(workspaceRoot, '.devcontainer', 'overlay', 'post-attach-commands.sh'),
+      'utf-8',
+    );
+    const calcRam = script.match(/calc_ram\(\) \{[\s\S]*?\n\}/)?.[0];
+
+    expect(calcRam).toBeDefined();
+    const output = execSync(
+      `bash -c '${calcRam}; calc_ram 10 7'`,
+      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim();
+    expect(output).toBe('1');
+  });
+
   test('Verify base image tools', () => {
     const output = execSync(
       'docker exec spark-devcontainer-test bash -c "hatch --version && /opt/spark/bin/spark-submit --version 2>&1"',

--- a/.devcontainer/overlay/post-attach-commands.sh
+++ b/.devcontainer/overlay/post-attach-commands.sh
@@ -80,7 +80,7 @@ validate_range() {
 calc_ram() {
     local pct=$1
     local total=$2
-    echo $(( (total * pct) / 100 ))
+    echo $(( (total * pct + 99) / 100 ))
 }
 
 calc_cores_clamped() {


### PR DESCRIPTION
## What changed

- Round calculated whole-GiB Spark memory allocations up instead of truncating them.
- Add a regression test for a 10% driver allocation on a 7 GiB devcontainer.

## Why

The devcontainer post-attach command failed to start Livy on smaller machines. With 7 GiB reported by `free -g` and the default 10% driver allocation, integer floor division generated `spark.driver.memory=0g`. Spark then invoked Java with `-Xmx0g`, causing the JVM to exit before Livy could start.

The adjusted calculation produces a valid 1 GiB driver allocation while retaining the configured 7 GiB executor allocation.

## Validation

- `bash -n .devcontainer/overlay/post-attach-commands.sh`
- Focused allocation checks: 10% of 7 GiB = 1 GiB; 100% of 7 GiB = 7 GiB
- `npx jest --config jest.config.ts --runInBand --runTestsByPath .devcontainer/devcontainer.test.ts --testNamePattern='Spark memory allocation does not truncate'`
- Patched post-attach command completed and Livy bound to port 8998
