### PR TITLE
fix: make profile template valid YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed `dbt init` failing to parse the adapter's `profile_template.yml`. The `workspace_name` hint's unquoted `Precedence:` text was interpreted as a YAML mapping delimiter; the hint is now quoted so project scaffolding can load the profile template. ([#266](https://github.com/microsoft/dbt-fabricspark/issues/266))
+
 ## v1.13.0
 
 ### Features

--- a/src/dbt/include/fabricspark/profile_template.yml
+++ b/src/dbt/include/fabricspark/profile_template.yml
@@ -38,7 +38,7 @@ prompts:
         type: 'bool'
         default: true
       workspace_name:
-        hint: Optional. Default workspace name for cross-workspace 4-part naming. When set and the target lakehouse has schemas enabled, all relations without an explicit model-level workspace_name will be prefixed with this workspace. Ignored for non-schema lakehouses. Precedence: model config(workspace_name=...) > this value.
+        hint: 'Optional. Default workspace name for cross-workspace 4-part naming. When set and the target lakehouse has schemas enabled, all relations without an explicit model-level workspace_name will be prefixed with this workspace. Ignored for non-schema lakehouses. Precedence: model config(workspace_name=...) > this value.'
       quote_identifiers:
         hint: When true, backtick-quotes table identifiers so Fabric Spark preserves their casing instead of folding to lowercase. Requires spark.sql.caseSensitive=true under spark_config.conf to take effect. Session-wide (also affects column resolution). Defaults to false.
         type: 'bool'

--- a/tests/unit/test_profile_template.py
+++ b/tests/unit/test_profile_template.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROFILE_TEMPLATE = REPO_ROOT / "src" / "dbt" / "include" / "fabricspark" / "profile_template.yml"
+
+
+def test_profile_template_is_valid_yaml() -> None:
+    template = yaml.safe_load(PROFILE_TEMPLATE.read_text(encoding="utf-8"))
+
+    workspace_prompt = template["prompts"]["_choose_authentication_method"]["livy"][
+        "workspace_name"
+    ]
+    assert workspace_prompt["hint"].endswith(
+        "Precedence: model config(workspace_name=...) > this value."
+    )


### PR DESCRIPTION
## Summary

- quote the `workspace_name` prompt hint so `dbt init` can parse the shipped profile template
- add a regression test that parses the complete template and verifies the prompt structure
- document the fix in the Unreleased changelog

## Validation

- `uv run pytest tests/unit/test_profile_template.py -vv`
- `npx nx run dbt-fabricspark:lint`
- `npx nx run dbt-fabricspark:build`
- `npx nx run dbt-fabricspark:test`

Closes #266
